### PR TITLE
Fixes use of correct parent pom version for API module

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>


### PR DESCRIPTION
Updates the API module parent version to 1.0. It should have been changed with the others but I missed it.