### PR TITLE
APPSERV-146 Adds bookmarkable page URLs 

### DIFF
--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -1005,6 +1005,7 @@ MonitoringConsole.Model = (function() {
 		if (UI.switchPage(pageId)) {
 			Charts.clear();
 			Interval.tick();
+			window.location.hash = pageId;
 		}
 		return UI.arrange();		
 	}

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -805,10 +805,22 @@ MonitoringConsole.View = (function() {
         Colors: Colors,
         Components: Components,
         onPageReady: function() {
+            let hash = window.location.hash;
+            let targetPageId = hash.length <= 1 ? undefined : hash.substring(1);
             // connect the view to the model by passing the 'onDataUpdate' function to the model
             // which will call it when data is received
-            onPageChange(MonitoringConsole.Model.init(onDataUpdate, onPageChange));
+            let layout = MonitoringConsole.Model.init(onDataUpdate, onPageChange);
+            if (targetPageId === undefined)
+                onPageChange(layout);
             Colors.scheme('Payara', false);
+            if (targetPageId)
+                onPageChange(MonitoringConsole.Model.Page.changeTo(targetPageId));
+            $(window).on('hashchange', function(e) {
+                let pageId = window.location.hash.substring(1);
+                if (pageId != MonitoringConsole.Model.Page.id()) {
+                    onPageChange(MonitoringConsole.Model.Page.changeTo(pageId));
+                }
+            });
         },
         onPageChange: (layout) => onPageChange(layout),
         onPageUpdate: (layout) => onPageUpdate(layout),


### PR DESCRIPTION
### Summary
Pages did already have an internal string ID that is derived from the name if not given by a preset. This ID is now used to represent the current page as `window.location.hash` value.

For example: http://x1:8080/monitoring-console-webapp/#core for the `Core` page.

This allows to jump to a page by changing the hash in the browser's location bar to another value.
Page changes performed by the menu will equally change the browsers location. 
This also means users can use the back and forward buttons of the browser to navigate to pages already visited. 

### Testing
1. Build MC webapp module and deploy the war file manually on a 5.201+ server.
2. Open MC on the app home. Use the menu to switch pages. 
3. Observe how the URL updates. 
4. Copy & paste the URL to another browser and check the page referenced by the ID opens (as opposed to page last visited)
5. Check that URL without a hash still opens the page last visited
6. Check that URLs with a hash for a page that does not exist does not change the current page (is ignored)