### PR TITLE
FISH-7 Adds Query Pages (Virtual Pages)

### DIFF
--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -28,7 +28,7 @@ state changes in case of reload.
 ```
 UI              = { pages, settings }
 pages           = { *: PAGE }
-PAGE            = { name, id, numberOfColumns, rotate, widgets, sync }
+PAGE            = { name, id, numberOfColumns, rotate, widgets, sync, virtual }
 name            = string
 id              = string
 numberOfColumns = number
@@ -53,6 +53,10 @@ autosync        = boolean
 lastModifiedLocally             = number
 basedOnRemoteLastModified       = number
 preferredOverRemoteLastModified = number
+content         = { series, maxSize, expires }
+series          = string
+maxSize         = number
+expires         = number
 ```
 * `id` is derived from `name` and used as attribute name in `pages` object
 * `widgets` can be omitted for an empty page
@@ -61,6 +65,9 @@ preferredOverRemoteLastModified = number
 * `home` is the `PAGE.id` of the currently shown page
 * names for `defaults` colors used so far are: `'alarming'`, `'critical'` and `'waterline'`
 * default for `role` is `'user'`
+* when a page has a `content` object it is considered a _arranged_ page (not strictly `widgets` based content)
+* `expires` is a timestamp when the content is expired and should be updated
+
 
 ### Widget Model
 

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -53,10 +53,11 @@ autosync        = boolean
 lastModifiedLocally             = number
 basedOnRemoteLastModified       = number
 preferredOverRemoteLastModified = number
-content         = { series, maxSize, expires }
+content         = { series, maxSize, expires, ttl }
 series          = string
 maxSize         = number
 expires         = number
+ttl             = number
 ```
 * `id` is derived from `name` and used as attribute name in `pages` object
 * `widgets` can be omitted for an empty page
@@ -67,6 +68,7 @@ expires         = number
 * default for `role` is `'user'`
 * when a page has a `content` object it is considered a _arranged_ page (not strictly `widgets` based content)
 * `expires` is a timestamp when the content is expired and should be updated
+* `ttl` number of seconds the page is valid
 
 
 ### Widget Model

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -72,11 +72,12 @@ expires         = number
 ### Widget Model
 
 ```
-WIDGET     = { id, series, type, unit, scaleFactor, target, grid, axis, options, decorations, status, displayName, coloring, fields, mode, sort }
+WIDGET     = { id, series, type, unit, scaleFactor, target, grid, axis, options, decorations, status, displayName, description, coloring, fields, mode, sort }
 id         = string
 series     = string | [string]
 target     = string
 displayName= string
+description= string
 type       = 'line' | 'bar' | 'alert' | 'annotation'
 unit       = UNIT
 UNIT       = 'count' | 'ms' | 'ns' | 'bytes' | 'percent'

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -28,7 +28,7 @@ state changes in case of reload.
 ```
 UI              = { pages, settings }
 pages           = { *: PAGE }
-PAGE            = { name, id, numberOfColumns, rotate, widgets, sync, virtual }
+PAGE            = { name, id, numberOfColumns, rotate, widgets, sync, content }
 name            = string
 id              = string
 numberOfColumns = number

--- a/webapp/src/main/java/fish/payara/monitoring/web/ApiRequests.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/ApiRequests.java
@@ -61,6 +61,7 @@ public final class ApiRequests {
     public static final class SeriesRequest {
 
         public SeriesQuery[] queries;
+        public boolean groupBySeries = false;
 
         public SeriesRequest() {
             // from JSON
@@ -124,6 +125,9 @@ public final class ApiRequests {
         }
 
         private static boolean contains(DataType[] set, DataType type) {
+            if (set == null) {
+                return false;
+            }
             for (DataType t : set) {
                 if (t == type) {
                     return true;

--- a/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
@@ -133,6 +133,16 @@ public final class ApiResponses {
             this.data = data.stream().map(set -> new SeriesData(set, query.truncates(POINTS))).collect(toList());
             this.annotations = annotations.stream().map(AnnotationData::new).collect(toList());
         }
+
+        public SeriesMatch(String series, List<SeriesData> data, List<AnnotationData> annotations,
+                List<WatchData> watches, List<AlertData> alerts) {
+            this.widgetId = "grouped";
+            this.series = series;
+            this.data = data;
+            this.annotations = annotations;
+            this.watches = watches;
+            this.alerts = alerts;
+        }
     }
 
     public static final class AnnotationData {

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -47,7 +47,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=a"></script>
+    <script src="js/monitoring-console.js?x=d"></script>
     <link href="css/monitoring-console.css?x=y" rel="stylesheet" type="text/css">
 </head>
 <body id="console">

--- a/webapp/src/main/webapp/js/mc-controller.js
+++ b/webapp/src/main/webapp/js/mc-controller.js
@@ -66,12 +66,14 @@ MonitoringConsole.Controller = (function() {
    }
 
    /**
-    * @param {array}    queries   - a JS array with query objects as expected by the server API (object corresponds to java class SeriesQuery)
-    * @param {function} onSuccess - a callback function with one argument accepting the response object as send by the server (java class SeriesResponse)
-    * @param {function} onFailure - a callback function with no arguments
+    * @param {array|object} queries   - a JS array with query objects as expected by the server API (object corresponds to java class SeriesQuery)
+    *                                   or a JS object corresponding to java class SeriesRequest
+    * @param {function}     onSuccess - a callback function with one argument accepting the response object as send by the server (java class SeriesResponse)
+    * @param {function}     onFailure - a callback function with no arguments
     */
    function requestListOfSeriesData(queries, onSuccess, onFailure) {
-      requestWithJsonBody('POST', 'api/series/data/', { queries: queries }, onSuccess, onFailure);
+      const request = !Array.isArray(queries) ? queries : { queries: queries }; 
+      requestWithJsonBody('POST', 'api/series/data/', request, onSuccess, onFailure);
    }
 
    /**

--- a/webapp/src/main/webapp/js/mc-data.js
+++ b/webapp/src/main/webapp/js/mc-data.js
@@ -300,8 +300,9 @@ MonitoringConsole.Data = (function() {
 		},
 		developer_metrics: {
 			name: 'Developer Metrics',
+			type: 'query',
 			numberOfColumns: 4,
-			content: { series: 'ns:metric ?:* *', maxSize: 30 },
+			content: { series: 'ns:metric ?:* *', maxSize: 30, ttl: 60 },
 		}
 	};
 

--- a/webapp/src/main/webapp/js/mc-data.js
+++ b/webapp/src/main/webapp/js/mc-data.js
@@ -297,6 +297,11 @@ MonitoringConsole.Data = (function() {
 				{ series: 'ns:jvm DaemonThreadCount', displayName: 'Daemon Threads', 
 					grid: {column: 3, item: 2}},							
 			],
+		},
+		developer_metrics: {
+			name: 'Developer Metrics',
+			numberOfColumns: 4,
+			content: { series: 'ns:metric ?:* *', maxSize: 30 },
 		}
 	};
 

--- a/webapp/src/main/webapp/js/mc-data.js
+++ b/webapp/src/main/webapp/js/mc-data.js
@@ -298,11 +298,11 @@ MonitoringConsole.Data = (function() {
 					grid: {column: 3, item: 2}},							
 			],
 		},
-		developer_metrics: {
-			name: 'Developer Metrics',
+		application_metrics: {
+			name: 'Application Metrics',
 			type: 'query',
 			numberOfColumns: 4,
-			content: { series: 'ns:metric ?:* *', maxSize: 30, ttl: 60 },
+			content: { series: 'ns:metric ?:* *', maxSize: 32, ttl: 60 },
 		}
 	};
 

--- a/webapp/src/main/webapp/js/mc-line-chart.js
+++ b/webapp/src/main/webapp/js/mc-line-chart.js
@@ -414,8 +414,8 @@ MonitoringConsole.Chart.Line = (function() {
       datasets = datasets.concat(createSeriesDatasets(widget, data[j], update.watches));
     }
     chart.data.datasets = datasets;
-    chart.data.areas = createBackgroundAreas(widget, update.watches);    
-    chart.update(0);
+    chart.data.areas = createBackgroundAreas(widget, update.watches);
+    chart.update(0);  
   }
   
   /**

--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -91,20 +91,28 @@ MonitoringConsole.Model = (function() {
 				page.id = getPageId(page.name);
 			if (!page.widgets)
 				page.widgets = {};
+			if (page.type === undefined)
+				page.type = 'manual';
 			if (typeof page.sync !== 'object')
 				page.sync = { autosync: true };
+			if (typeof page.content !== 'object')
+				page.content = {};
 			if (!page.numberOfColumns || page.numberOfColumns < 1)
 				page.numberOfColumns = 1;
 			if (page.rotate === undefined)
 				page.rotate = true;
-			// make widgets from array to object if needed
-			let widgetsArray = Array.isArray(page.widgets) ? page.widgets : Object.values(page.widgets);
-			widgetsArray.forEach(sanityCheckWidget);
-			let widgets = {};
-			for (let widget of widgetsArray)
-				widgets[widget.id] = widget;
-			page.widgets = widgets;
+			page.widgets = sanityCheckWidgets(page.widgets);
 			return page;
+		}
+
+		function sanityCheckWidgets(widgets) {
+			// make widgets from array to object if needed
+			let widgetsArray = Array.isArray(widgets) ? widgets : Object.values(widgets);
+			widgetsArray.forEach(sanityCheckWidget);
+			let widgetsObj = {};
+			for (let widget of widgetsArray)
+				widgetsObj[widget.id] = widget;
+			return widgetsObj;
 		}
 		
 		/**
@@ -448,7 +456,8 @@ MonitoringConsole.Model = (function() {
 	      bytes: 'bytes',
    		};
 
-      	async function doArrangePage(page) {
+      	async function doQueryPage() {
+      		const page = pages[settings.home];
       		function yAxisUnit(metadata) {
       			if (Y_AXIS_UNIT[metadata.Unit] !== undefined)
       				return Y_AXIS_UNIT[metadata.Unit];
@@ -469,30 +478,34 @@ MonitoringConsole.Model = (function() {
       			() => reject(undefined));
 
 			});
-			const matches = await content;
+			let matches = await content;
 			matches.sort((a, b) => a.data[0].stableCount - b.data[0].stableCount);
+			if (matches.length > page.content.maxSize)
+				matches = matches.slice(0, page.content.maxSize);
 			const widgets = [];
 			const numberOfColumns = page.numberOfColumns;
 			let column = 0;
 			for (let i = 0; i < matches.length; i++) {
 				let match = matches[i];
 				let metadata = match.annotations.filter(a => a.permanent)[0];
+				let attrs = metadata === undefined ? {} : metadata.attrs || {};
 				let data = match.data[0];
 				let scaleFactor;
-				if (metadata.attrs.ScaleToBaseUnit > 1) {
-					scaleFactor = Number(metadata.attrs.ScaleToBaseUnit);
+				if (attrs.ScaleToBaseUnit > 1) {
+					scaleFactor = Number(attrs.ScaleToBaseUnit);
 				}
-				let decimalMetric = metadata.attrs.Type == 'gauge';
-				let unit = yAxisUnit(metadata.attrs);
+				let decimalMetric = attrs.Type == 'gauge';
+				let unit = yAxisUnit(attrs);
 				let max = decimalMetric ? 10000 : 1;
-				if (metadata.attrs.Unit == 'none' && data.observedMax <= max && data.observedMin >= 0) {
+				if (attrs.Unit == 'none' && data.observedMax <= max && data.observedMin >= 0) {
 					unit = 'percent';
 					scaleFactor = 100;
 				}
 				widgets.push({
+					id: match.series,
 					series: match.series,
-					displayName: metadata.attrs.DisplayName,
-					description: metadata.attrs.Description,
+					displayName: attrs.DisplayName,
+					description: attrs.Description,
 					grid: { column: column % numberOfColumns, item: column },
 					unit: unit,
 					options: { 
@@ -502,8 +515,10 @@ MonitoringConsole.Model = (function() {
 				});
 				column++;
 			}
-			page.widgets = widgets;
-			sanityCheckPage(page);
+			page.widgets = sanityCheckWidgets(widgets);
+			page.content.expires = new Date().getTime() + ((page.content.ttl || (60 * 60 * 24 * 365)) * 1000);
+			doStore(true, page);
+			return page;
       	}
 
 		return {
@@ -527,7 +542,7 @@ MonitoringConsole.Model = (function() {
 
 			currentPage: function() {
 				return pages[settings.home];
-			},
+			},			
 			
 			listPages: function() {
 				return Object.values(pages).map(function(page) { 
@@ -556,6 +571,8 @@ MonitoringConsole.Model = (function() {
 				if (onImportComplete)
 					onImportComplete();
 			},
+
+			queryPage: () => doQueryPage(),
 			
 			/**
 			 * Loads and returns the userInterface from the local storage
@@ -589,6 +606,12 @@ MonitoringConsole.Model = (function() {
 				settings.home = pageId;
 				doStore(true);
 				return true;
+			},
+
+			configurePage: function(change) {
+				const page = pages[settings.home];
+				change(page);
+				doStore(true, page);
 			},
 			
 			/**
@@ -639,13 +662,7 @@ MonitoringConsole.Model = (function() {
 				if (!pages[pageId])
 					return undefined;
 				settings.home = pageId;
-				const page = pages[settings.home];
-				if (page.content !== undefined) {
-					const now = new Date().getTime();
-					if (page.expires === undefined || now >= page.expires)
-						doArrangePage(page);
-				}
-				return page;
+				return pages[settings.home];
 			},
 
 			rotatePage: function(rotate) {
@@ -1210,8 +1227,16 @@ MonitoringConsole.Model = (function() {
 
 	function doInit(onDataUpdate, onPageUpdate) {
 		UI.load();
-		Interval.init(function() {
-			let widgets = UI.currentPage().widgets;
+		Interval.init(async function() {
+			let page = UI.currentPage();
+			if (page.type == 'query') {
+				const now = new Date().getTime();
+				if (page.widgets === undefined || page.content.expires === undefined || now >= page.content.expires) {
+					page = await UI.queryPage();
+					onPageUpdate(doSwitchPage(page.id));
+				}
+			}
+			let widgets = page.widgets;
 			Controller.requestListOfSeriesData(Update.createQuery(widgets), 
 				Update.createOnSuccess(widgets, onDataUpdate),
 				Update.createOnError(widgets, onDataUpdate));
@@ -1346,6 +1371,11 @@ MonitoringConsole.Model = (function() {
 		 */
 		Page: {
 			
+			current: () => UI.currentPage(),
+			configure: function(change) {
+				UI.configurePage(change);
+				return UI.arrange();
+			},
 			id: () => UI.currentPage().id,
 			name: () => UI.currentPage().name,
 			rename: UI.renamePage,

--- a/webapp/src/main/webapp/js/mc-view-units.js
+++ b/webapp/src/main/webapp/js/mc-view-units.js
@@ -74,6 +74,19 @@ MonitoringConsole.View.Units = (function() {
    };
 
    /**
+    * Factors used for any time unit to microseconds
+    */
+   const US_FACTORS = {
+      h: 60 * 60 * 1000 * 1000, hours: 60 * 60 * 1000 * 1000,
+      m: 60 * 1000 * 1000, min: 60 * 1000 * 1000, mins: 60 * 1000 * 1000,
+      s: 1000 * 1000, sec: 1000 * 1000, secs: 1000 * 1000,
+      ms: 1000,
+      us: 1, μs: 1,
+      ns: 1/1000,
+      _: [['h', 'm'], ['h', 'm', 's'], ['h', 'm', 's', 'ms'], ['m', 's'], ['m', 's', 'ms'], ['s', 'ms'], ['ms', 'us']]
+   };
+
+   /**
     * Factors used for any time unit to nanoseconds
     */
    const NS_FACTORS = {
@@ -83,7 +96,7 @@ MonitoringConsole.View.Units = (function() {
       ms: 1000000,
       us: 1000, μs: 1000,
       ns: 1,
-      _: [['h', 'm'], ['h', 'm', 's'], ['h', 'm', 's', 'ms'], ['m', 's'], ['m', 's', 'ms'], ['s', 'ms']]
+      _: [['h', 'm'], ['h', 'm', 's'], ['h', 'm', 's', 'ms'], ['m', 's'], ['m', 's', 'ms'], ['s', 'ms'], ['ms', 'us', 'ns'], ['ms', 'us']]
    };
 
    /**
@@ -111,14 +124,17 @@ MonitoringConsole.View.Units = (function() {
       count: COUNT_FACTORS,
       sec: SEC_FACTORS,
       ms: MS_FACTORS,
+      us: US_FACTORS,
       ns: NS_FACTORS,
       bytes: BYTES_FACTORS,
       percent: PERCENT_FACTORS,
    };
 
    const UNIT_NAMES = {
-      count: 'Count', 
-      ms: 'Milliseconds', 
+      count: 'Count',
+      sec: 'Seconds', 
+      ms: 'Milliseconds',
+      us: 'Microseconds',
       ns: 'Nanoseconds', 
       bytes: 'Bytes', 
       percent: 'Percentage'
@@ -284,7 +300,6 @@ MonitoringConsole.View.Units = (function() {
       },
       
       names: () => UNIT_NAMES,
-
       formatTime: formatTime,
       formatDateTime: formatDateTime,
       formatNumber: formatNumber,

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -217,7 +217,7 @@ MonitoringConsole.View = (function() {
         let title = widget.displayName ? widget.displayName : formatSeriesName(widget.series);
         return $('<div/>', {"class": "widget-title-bar"})
             .append(Components.createMenu(menu))
-            .append($('<h3/>', {title: widget.series})
+            .append($('<h3/>', {title: widget.description != '' ? widget.description : widget.series})
                 .html(title)
                 .click(() => onWidgetToolbarClick(widget)))            
             ;

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -425,12 +425,22 @@ MonitoringConsole.View = (function() {
         let pushAvailable = !MonitoringConsole.Model.Role.isGuest() && MonitoringConsole.Model.Page.Sync.isLocallyChanged() && MonitoringConsole.Model.Role.isAdmin();
         let pullAvailable = !MonitoringConsole.Model.Role.isGuest();
         let autoAvailable = MonitoringConsole.Model.Role.isAdmin();
+        let page = MonitoringConsole.Model.Page.current();
+        let queryAvailable = page.type === 'query';
+        const configure =  MonitoringConsole.Model.Page.configure;
         return { id: 'settings-page', caption: 'Page', collapsed: collapsed, entries: [
             { label: 'Name', type: 'text', value: MonitoringConsole.Model.Page.name(), onChange: pageNameOnChange },
             { label: 'Page Rotation', input: [
                 { label: 'Include in Rotation', type: 'checkbox', value: MonitoringConsole.Model.Page.rotate(), onChange: (checked) => MonitoringConsole.Model.Page.rotate(checked) },
             ]},
-            { label: 'Add Widgets', input: () => 
+            { label: 'Type', type: 'dropdown', options: {manual: 'Manual', query: 'Query'}, value: page.type, onChange: (type) => { onPageUpdate(configure(page => page.type = type)); updateSettings(); } },            
+            { label: 'Max Size', available: queryAvailable, type: 'value', min: 1, unit: 'count', value: page.content.maxSize || 16,  onChange: (value) => configure(page => page.content.maxSize = value) },
+            { label: 'Query Series', available: queryAvailable, type: 'text', value: page.content.series, onChange: (value) => configure(page => page.content.series = value) },
+            { label: 'Query Interval', available: queryAvailable, input: [
+                { type: 'value', min: 1, unit: 'sec', value: page.content.ttl, onChange: (value) => configure(page => page.content.ttl = value) },
+                { input: $('<button/>', {text: 'Reset'}).click(() => configure(page => page.content.expires = undefined)) },
+            ]},
+            { label: 'Add Widgets', available: !queryAvailable, input: () => 
                 $('<span/>')
                 .append(nsSelection)
                 .append(widgetsSelection)

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -434,7 +434,7 @@ MonitoringConsole.View = (function() {
                 { label: 'Include in Rotation', type: 'checkbox', value: MonitoringConsole.Model.Page.rotate(), onChange: (checked) => MonitoringConsole.Model.Page.rotate(checked) },
             ]},
             { label: 'Type', type: 'dropdown', options: {manual: 'Manual', query: 'Query'}, value: page.type, onChange: (type) => { onPageUpdate(configure(page => page.type = type)); updateSettings(); } },            
-            { label: 'Max Size', available: queryAvailable, type: 'value', min: 1, unit: 'count', value: page.content.maxSize || 16,  onChange: (value) => configure(page => page.content.maxSize = value) },
+            { label: 'Max Size', available: queryAvailable, type: 'value', min: 1, unit: 'count', value: page.content.maxSize,  onChange: (value) => configure(page => page.content.maxSize = value) },
             { label: 'Query Series', available: queryAvailable, type: 'text', value: page.content.series, onChange: (value) => configure(page => page.content.series = value) },
             { label: 'Query Interval', available: queryAvailable, input: [
                 { type: 'value', min: 1, unit: 'sec', value: page.content.ttl, onChange: (value) => configure(page => page.content.ttl = value) },

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -438,7 +438,7 @@ MonitoringConsole.View = (function() {
             { label: 'Query Series', available: queryAvailable, type: 'text', value: page.content.series, onChange: (value) => configure(page => page.content.series = value) },
             { label: 'Query Interval', available: queryAvailable, input: [
                 { type: 'value', min: 1, unit: 'sec', value: page.content.ttl, onChange: (value) => configure(page => page.content.ttl = value) },
-                { input: $('<button/>', {text: 'Reset'}).click(() => configure(page => page.content.expires = undefined)) },
+                { input: $('<button/>', {text: 'Update'}).click(() => configure(page => page.content.expires = undefined)) },
             ]},
             { label: 'Add Widgets', available: !queryAvailable, input: () => 
                 $('<span/>')


### PR DESCRIPTION
### Summary
For lack of a better name this PR adds a new type of page called _query page_ (previously a.k.a. _virtual page_).
In contrast to the only type of page that existed before (which is now called a _manual page_) the widgets on a query page are not added and configured manually (hence manual page) by the user but result from a series query given by the user as part of the page configuration.

The query series usually involves wildcards `*` in the series so that it potentially matches multiple actual series. Matches are ordered by rate of change (starting with most frequently changing) and distributed on the page. To avoid enormous pages a limit is set to the number of widgets/series shown on the page. The query is repeated in an interval updating the widget/series shown on the page. All of this parameters can be edited as part of the _Page_ settings as soon as the _Type_ has been changed to _Query_.

![screenshot-x1_8080-2020 07 07-13_14_56](https://user-images.githubusercontent.com/309438/86795349-bf334d00-c06d-11ea-9fe4-86825c8e5166.png)

To force an update the _Reset_ button next to the interval time can be used.

#### Application Metrics Preset
The query page feature is then used by the new _Application Metrics_ page preset. It uses the series `ns:metric ?:* *` (any series in namespace `metric` - which are series resulting from MP Metrics of both the server and deployed applications)

The special thing about series from MP Metrics is their metadata that is available in MC as annotation. This information is utilised by the client to bootstrap the widgets with proper unit configuration. Also the widgets have the same title/display name as given by the MP Metrics and have a tooltip text originating from the MP Metric description.

While other query pages can be build, e.g. try `ns:jvm *` there are no such information available for the series and the resulting page considers the unit to be a `count` (default).

Users can also chose to edit query pages. If they intend to do so they can set the _Query Interval_ to a long interval, say _1000days_. This practically freezes the page after the initial query and the user can do all manual changes to the widgets and the page as it is possible for manual pages. However, after the interval the page will eventually update and the changes are lost. Users can also change the page _Type_ back to _Manual_ after it had been populated by a query in order to prevent any automatic changes to the configuration.


### Testing
Ideally build Payara with https://github.com/payara/Payara/pull/4772 and deploy the war files created by `mvn clean install` of the updated `monitoring-console/webapp`. The general feature does work without the Payara changes but then the MP Metrics lack two added fields of the annotation resulting in less accurate unit configuration of the widgets added to the page as a result of the query.

#### Testing Performed
Manual testing.

With MC webapp deployed open monitoring console and check

1. new _Application Metrics_ page exists and has content
2. check individual metrics have reasonable unit, e.g. memory is given in bytes, GC time in some time unit, thread count as count
3. check the widgets have a display name (widget title) that corresponds to the display name of the MP Metric
4. check the tooltip on the title is the MP Metric metadata description (if any text appears this works as there are no other sources for this text)
5. check that changes to the page content settins (_Query Series_, _Query Interval_, _Max Size_) are applied after clicking _Reset_
6. set a short _Query Interval_ (e.g. `5s` - 5 seconds) and check that the page is updated after that interval (e.g. open settings - if settings closes page got updated)
7. set a long _Query Interval_ and check page is not updated
8. create a new page, change type to _Query_ and put _Query Series_ `ns:jvm *` (use _Reset_ button to apply)
9. change layout to 4 column and (use _Reset_ button to apply again or wait the interval time)
10. change _Query Series_ to `ns:web *` or `ns:http *` (needs configuration of _Monitoring_ levels to _HIGH_ in admin console) and check those series are shown on the page after a reset

**Note**: It is intentional that changes to certain properties need explicit use of _Reset_ or otherwise will take effect when next query interval starts. This almost must work this way as otherwise the page would "suddenly" empty and "jump around" while changing these properties. This wasn't a good user experience. 

**Note** also that it is by design that settings might close on you when the page refreshed from a query being applied in case it has been open only because a widget was selected. The selection is part of the widget state which is reset when page is rebuild from a query. This might not be ideal but is a consequence of the current model for the selection.

### Documentation
https://github.com/payara/Payara-Community-Documentation/pull/42