### PR TITLE
FISH-257 Adds RAG Status Widget Types

### DIFF
--- a/process/src/main/java/fish/payara/monitoring/alert/Circumstance.java
+++ b/process/src/main/java/fish/payara/monitoring/alert/Circumstance.java
@@ -39,6 +39,8 @@
  */
 package fish.payara.monitoring.alert;
 
+import java.io.Serializable;
+
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
@@ -54,7 +56,7 @@ import fish.payara.monitoring.model.SeriesDataset;
  *
  * @author Jan Bernitt
  */
-public final class Circumstance {
+public final class Circumstance implements Serializable {
 
     /**
      * A "null" value object to use for a {@link Circumstance} that does not exist.
@@ -128,7 +130,7 @@ public final class Circumstance {
 
     public boolean equalTo(Circumstance other) {
         return level == other.level && start.equalTo(other.start) && stop.equalTo(other.stop)
-                && suppress.equalTo(other.suppress) 
+                && suppress.equalTo(other.suppress)
                 && (suppressing == null && other.suppressing == null || suppressing != null && suppressing.equalTo(other.suppressing));
     }
 
@@ -167,7 +169,7 @@ public final class Circumstance {
         }
         JsonObject obj = value.asJsonObject();
         return new Circumstance(
-                Level.parse(obj.getString("level")), 
+                Level.parse(obj.getString("level")),
                 Condition.fromJSON(obj.get("start")),
                 Condition.fromJSON(obj.get("stop")),
                 Metric.fromJSON(obj.get("suppressing")),

--- a/process/src/main/java/fish/payara/monitoring/alert/Condition.java
+++ b/process/src/main/java/fish/payara/monitoring/alert/Condition.java
@@ -42,6 +42,7 @@ package fish.payara.monitoring.alert;
 import static java.lang.Math.abs;
 import static java.lang.Math.min;
 
+import java.io.Serializable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -54,16 +55,16 @@ import fish.payara.monitoring.model.SeriesDataset;
 
 /**
  * Describes when a {@link SeriesDataset} {@link #isSatisfied(SeriesDataset)}.
- * 
+ *
  * In the simplest form this is a plain comparison with a constant {@link #threshold} value.
- * 
+ *
  * More advanced {@link Condition}s check if the condition is satisfied for last number of values in the dataset or for
  * a past number of milliseconds. Such checks either check each included value of the dataset against the threshold
  * (ALL) or compare their average against the threshold in a single check for any number of included values.
- * 
+ *
  * @author Jan Berntitt
  */
-public final class Condition {
+public final class Condition implements Serializable {
 
     private static final String FOR_TIMES = "forTimes";
     private static final String FOR_MILLIS = "forMillis";
@@ -123,7 +124,7 @@ public final class Condition {
     }
 
     public boolean isNone() {
-        return this == NONE;
+        return this == NONE || equalTo(NONE);
     }
 
     public boolean isForLastPresent() {
@@ -317,7 +318,7 @@ public final class Condition {
             forLast = obj.getInt(FOR_TIMES);
         }
         return new Condition(
-                Operator.parse(obj.getString("comparison", ">")), 
+                Operator.parse(obj.getString("comparison", ">")),
                 obj.getJsonNumber("threshold").longValue(),
                 forLast,
                 obj.getBoolean("onAverage", false));

--- a/process/src/main/java/fish/payara/monitoring/internal/alert/InMemoryAlarmService.java
+++ b/process/src/main/java/fish/payara/monitoring/internal/alert/InMemoryAlarmService.java
@@ -65,7 +65,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import fish.payara.monitoring.adapt.MonitoringConsoleRuntime;
 import fish.payara.monitoring.adapt.MonitoringConsoleWatchConfig;

--- a/process/src/main/java/fish/payara/monitoring/model/Metric.java
+++ b/process/src/main/java/fish/payara/monitoring/model/Metric.java
@@ -39,11 +39,13 @@
  */
 package fish.payara.monitoring.model;
 
+import java.io.Serializable;
+
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 
-public final class Metric {
+public final class Metric implements Serializable {
 
     public final Series series;
     public final Unit unit;

--- a/process/src/main/java/fish/payara/monitoring/model/Unit.java
+++ b/process/src/main/java/fish/payara/monitoring/model/Unit.java
@@ -41,7 +41,7 @@ package fish.payara.monitoring.model;
 
 /**
  * A {@link Unit} describes the type of values of a {@link SeriesDataset}.
- * 
+ *
  * @author Jan Bernitt
  */
 public enum Unit {
@@ -51,7 +51,8 @@ public enum Unit {
     BYTES("bytes"),
     SECONDS("sec"),
     MILLIS("ms"),
-    NANOS("ns");
+    NANOS("ns"),
+    UPDOWN("updown");
 
     public static Unit fromShortName(String shortName) {
         for (Unit u : values()) {

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -391,6 +391,21 @@ text      = string
 color     = string
 ```
 
+### RAG Indicator API
+Describes the model expected by the `RAGIndicator` component.
+This component gives a simple Red-Amber-Green status indication on the state of the series shown in the widget.
+
+```
+RAG_INDICATOR = { items }
+items         = [ RAG_ITEM ]
+RAG_ITEM      = { label, status, color, background }
+label         = string
+state         = string
+status        = Status
+color         = string
+background    = string
+```
+
 
 ### Menu API
 Describes the model expected by the `MENU` component that is used for any of the text + icon menus or toolbars.

--- a/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
@@ -39,7 +39,6 @@
  */
 package fish.payara.monitoring.web;
 
-import static fish.payara.monitoring.web.ApiRequests.DataType.POINTS;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
@@ -47,9 +46,7 @@ import static java.util.stream.StreamSupport.stream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/webapp/src/main/webapp/css/monitoring-console.css
+++ b/webapp/src/main/webapp/css/monitoring-console.css
@@ -445,6 +445,30 @@ table.tags th, table.tags td {
 }
 
 
+/* RAG Indicator */
+.RAGIndicator {
+  text-align: center;
+  position: absolute;
+  width: 100%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  top: 40px;
+  height: calc(100% - 40px);
+}
+
+.RAGIndicator .Item {
+  font-size: 160%;
+  font-weight: bold;
+  border-left: 5px solid transparent;
+  padding: 5px;
+  box-sizing: border-box;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  display: flex;
+  border-bottom: 2px solid #001A25;
+}
+
 /* Page Navigation */
 #Navigation {
   float: left;

--- a/webapp/src/main/webapp/js/mc-data.js
+++ b/webapp/src/main/webapp/js/mc-data.js
@@ -112,6 +112,12 @@ MonitoringConsole.Data = (function() {
 					status: { missing: { hint: TEXT_WEB_HIGH }}},
 			]
 		},
+		rag: {
+			name: 'RAG Status',
+			numberOfColumns: 4,
+			type: 'query',
+			content: { series: 'ns:health ?:* *', maxSize: 32, ttl: 60 },
+		},
 		request_tracing: {
 			name: 'Request Tracing',
 			numberOfColumns: 4,

--- a/webapp/src/main/webapp/js/mc-view-components.js
+++ b/webapp/src/main/webapp/js/mc-view-components.js
@@ -476,6 +476,29 @@ MonitoringConsole.View.Components = (function() {
     return { createComponent: createComponent };
   })();
 
+
+  const RAGIndicator = (function() {
+
+    function createComponent(model) {
+      const indicator = $('<div/>', { 'class': 'RAGIndicator' });
+      const itemHeight = Math.floor(100 / model.items.length);
+      for (let item of model.items) {
+        let text = item.label;
+        if (text == 'server')
+          text = 'DAS';
+        indicator.append($('<div/>', { 
+          title: item.state, 
+          'class': 'Item', 
+          style: 'background-color: '+item.background+ '; height: '+itemHeight+'%; border-left-color: '+item.color+';' })
+        .append($('<span/>').text(text)));
+      }
+      return indicator;
+    }
+
+    return { createComponent: createComponent };
+
+  })();
+
   /**
    * Component for any of the text+icon menus/toolbars.
    */
@@ -1539,6 +1562,7 @@ MonitoringConsole.View.Components = (function() {
       createRoleSelector: (model) => RoleSelector.createComponent(model),
       createModalDialog: (model) => ModalDialog.createComponent(model),
       createSelectionWizard: (model) => SelectionWizard.createComponent(model),
+      createRAGIndicator: (model) => RAGIndicator.createComponent(model),
   };
 
 })();

--- a/webapp/src/main/webapp/js/mc-view-components.js
+++ b/webapp/src/main/webapp/js/mc-view-components.js
@@ -901,7 +901,7 @@ MonitoringConsole.View.Components = (function() {
       let text = '<b>' + levelText + ':</b> <em>If</em> ' + series + ' <em>in</em> ' + Units.names()[unit] + ' <em>is</em> ';
       text += plainText(formatCondition(model.start, unit));
       if (model.suppress)
-        text += ' <em>unless</em> ' + model.surpressingSeries + ' ' + plainText(formatCondition(model.suppress, modelsurpressingUnit));
+        text += ' <em>unless</em> ' + model.surpressingSeries + ' ' + plainText(formatCondition(model.suppress, model.surpressingUnit));
       if (model.stop)
         text += ' <em>until</em> ' + plainText(formatCondition(model.stop, unit));
       return circumstance.html(text);

--- a/webapp/src/main/webapp/js/mc-view-units.js
+++ b/webapp/src/main/webapp/js/mc-view-units.js
@@ -128,6 +128,7 @@ MonitoringConsole.View.Units = (function() {
       ns: NS_FACTORS,
       bytes: BYTES_FACTORS,
       percent: PERCENT_FACTORS,
+      updown: {},
    };
 
    const UNIT_NAMES = {
@@ -137,7 +138,8 @@ MonitoringConsole.View.Units = (function() {
       us: 'Microseconds',
       ns: 'Nanoseconds', 
       bytes: 'Bytes', 
-      percent: 'Percentage'
+      percent: 'Percentage',
+      updown: 'Up/Down',
    };
 
    const ALERT_STATUS_NAMES = { 
@@ -311,6 +313,13 @@ MonitoringConsole.View.Units = (function() {
       parseNanoseconds: (valueAsString) => parseNumber(valueAsString, NS_FACTORS),
       parseBytes: (valueAsString) => parseNumber(valueAsString, BYTES_FACTORS),
       converter: function(unit) {
+         if (unit == 'updown')
+            return {
+               format: (stateAsNumber) => stateAsNumber == 0 ? 'Down' : 'Up',
+               parse: (stateAsString) => stateAsString == 'Down' || stateAsString == '0' ? 0 : 1,
+               pattern: () => 'up|down|0|1',
+               patternHint: () => 'up, down, 0, 1'
+            };
          let factors = FACTORS[unit];
          return {
             format: (valueAsNumber, useDecimals) => formatNumber(valueAsNumber, factors, useDecimals),


### PR DESCRIPTION
### Summary
This PR adds:

* synchronisation of watches from instances to the DAS (java)
* new unit type `updown` (Up/Down)
* new widget type `rag` (RAG Status)
* new page "RAG Status" (automatically populated with all available health check metrics, metrics with watches linked to type `updown` automatically use the `rag` indicator widget type and other configurations)

### Testing
#### Testing Performed
**Preparation:** Do a full build of parara server or:

* use a reasonably recent state of Payara master and build module changed by https://github.com/payara/Payara/pull/4819 and copy its jar to `glassfish/modules`
* build MC process and copy jar to `glassfish/modules`
* build MC webapp and deploy it manually on DAS

**Testing:**

* create another instance
* deploy an app with MP Health Checks, for example clone, build and deploy https://github.com/GEDOPLAN/health-demo on that instance
* open MC and navigate to page "RAG Status" and check numerous widgets appear showing the instance in UP state

![screenshot-x1_8080-2020 08 06-17_28_49](https://user-images.githubusercontent.com/309438/89619557-71894a80-d88e-11ea-9e12-15b1881b4edb.png)

* navigate to watches page, and check numerous watches with name _RAG <something>_ exist (now you check watch sync from other instances works)
* also deploy the test app on the DAS
* check "RAG Status" page again, it should (after a while) also show status of the DAS as UP (similar to screenshot)
* now open the home page of the test app for both the instance and the DAS, there are checkboxes to flip the status of the services to DOWN. Use them and check the change is reflected in the RAG Status page in the series for the service and in all aggregating series. (**changes can take up to 15sec to become visible** as checks are performed in 12sec intervals and client polls in 2sec intervals)

**Bonus:** Check out a RAG metric as line chart 
* Create a new page
* add a widget (or two) for with series in namespace `health` (starts `ns:health `)
* change data unit to `Up/Down`, this now should look similar to the below screenshot:

![screenshot-x1_8080-2020 08 06-17_30_46](https://user-images.githubusercontent.com/309438/89620268-b82b7480-d88f-11ea-96c1-181bb9cbeb0e.png)

Alternatively it is also possible to simply edit one of the widget on the "RAG Status" page and change its widget type to "Time Curve". This will however reset automatically after a while as the page is automatically assembled and updates every minute.

### Documentation
Pending...