### PR TITLE
Payara InSight v1.4 Release

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.4</version>
+    <version>1.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>


### PR DESCRIPTION
As usual 2 commits, first going to the released version`1.4`, second one going to next SNAPSHOT version `1.5-SNAPSHOT`.
Like before the API has no changes and is not released. Only modules `process` and `webapp` should be released in `1.4` to maven central.