### PR TITLE
FISH-527 Alert Centre 1.0

### DIFF
--- a/process/src/main/java/fish/payara/monitoring/alert/AlertService.java
+++ b/process/src/main/java/fish/payara/monitoring/alert/AlertService.java
@@ -67,6 +67,7 @@ public interface AlertService {
         public int unacknowledgedAmberAlerts;
         public int acknowledgedAmberAlerts;
         public int watches;
+        public int[] ongoingAlertSerials;
     }
 
     AlertStatistics getAlertStatistics();
@@ -105,7 +106,7 @@ public interface AlertService {
 
     /**
      * Removes the given watch. Alerts triggered by this watch will end now.
-     * 
+     *
      * @param watch the watch to end, not null
      */
     void removeWatch(Watch watch);

--- a/process/src/main/java/fish/payara/monitoring/alert/AlertService.java
+++ b/process/src/main/java/fish/payara/monitoring/alert/AlertService.java
@@ -67,7 +67,8 @@ public interface AlertService {
         public int unacknowledgedAmberAlerts;
         public int acknowledgedAmberAlerts;
         public int watches;
-        public int[] ongoingAlertSerials;
+        public int[] ongoingRedAlerts;
+        public int[] ongoingAmberAlerts;
     }
 
     AlertStatistics getAlertStatistics();

--- a/process/src/main/java/fish/payara/monitoring/internal/alert/InMemoryAlarmService.java
+++ b/process/src/main/java/fish/payara/monitoring/internal/alert/InMemoryAlarmService.java
@@ -431,7 +431,8 @@ public class InMemoryAlarmService implements AlertService {
         if (alerts.isEmpty()) {
             return stats;
         }
-        List<Integer> serials = new ArrayList<>();
+        List<Integer> redSerials = new ArrayList<>();
+        List<Integer> amberSerials = new ArrayList<>();
         for (Deque<Alert> seriesAlerts : alerts.values()) {
             for (Alert a : seriesAlerts) {
                 if (a.getLevel() == Level.RED) {
@@ -440,18 +441,19 @@ public class InMemoryAlarmService implements AlertService {
                     } else {
                         stats.unacknowledgedRedAlerts++;
                     }
-                    serials.add(a.serial);
+                    redSerials.add(a.serial);
                 } else if (a.getLevel() == Level.AMBER) {
                     if (a.isAcknowledged()) {
                         stats.acknowledgedAmberAlerts++;
                     } else {
                         stats.unacknowledgedAmberAlerts++;
                     }
-                    serials.add(a.serial);
+                    amberSerials.add(a.serial);
                 }
             }
         }
-        stats.ongoingAlertSerials = serials.isEmpty() ? new int[0] : serials.stream().mapToInt(e -> e).toArray();
+        stats.ongoingRedAlerts = redSerials.isEmpty() ? new int[0] : redSerials.stream().mapToInt(e -> e).toArray();
+        stats.ongoingAmberAlerts = amberSerials.isEmpty() ? new int[0] : amberSerials.stream().mapToInt(e -> e).toArray();
         return stats;
     }
 

--- a/process/src/main/java/fish/payara/monitoring/internal/alert/InMemoryAlarmService.java
+++ b/process/src/main/java/fish/payara/monitoring/internal/alert/InMemoryAlarmService.java
@@ -431,6 +431,7 @@ public class InMemoryAlarmService implements AlertService {
         if (alerts.isEmpty()) {
             return stats;
         }
+        List<Integer> serials = new ArrayList<>();
         for (Deque<Alert> seriesAlerts : alerts.values()) {
             for (Alert a : seriesAlerts) {
                 if (a.getLevel() == Level.RED) {
@@ -439,15 +440,18 @@ public class InMemoryAlarmService implements AlertService {
                     } else {
                         stats.unacknowledgedRedAlerts++;
                     }
+                    serials.add(a.serial);
                 } else if (a.getLevel() == Level.AMBER) {
                     if (a.isAcknowledged()) {
                         stats.acknowledgedAmberAlerts++;
                     } else {
                         stats.unacknowledgedAmberAlerts++;
                     }
+                    serials.add(a.serial);
                 }
             }
         }
+        stats.ongoingAlertSerials = serials.isEmpty() ? new int[0] : serials.stream().mapToInt(e -> e).toArray();
         return stats;
     }
 

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -59,11 +59,12 @@ maxSize         = number
 expires         = number
 ttl             = number
 filter          = 'line' | 'bar' | 'alert' | 'annotation' | 'rag' | undefined
-alerts          = { noPopupRed, noPopupAmber, confirmedChangeCount, confirmedSerials }
-noPopupRed      = boolean
-noPopupAmber    = boolean
-confirmedChangeCount = number
-confirmedSerials     = [ number ]
+alerts          = { noPopup, confirmed }
+noPopup         = boolean
+confirmed       = { changeCount, redAlerts, amberAlerts }
+changeCount     = number
+redAlerts       = [ number ]
+amberAlerts     = [ number ]
 ```
 * `id` is derived from `name` and used as attribute name in `pages` object
 * `widgets` can be omitted for an empty page

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -34,7 +34,7 @@ id              = string
 numberOfColumns = number
 rotate          = boolean
 widgets         = [WIDGET] | { *: WIDGET }
-settings        = { display, home, refresh, rotation, theme, role }
+settings        = { display, home, refresh, rotation, theme, role, alerts }
 display         = boolean
 home            = string
 refresh         = { paused, interval }
@@ -48,6 +48,9 @@ colors          = { *:COLOR }
 options         = { *:number }
 COLOR           = string
 role            = 'admin' | 'user' | 'guest'
+alerts          = { noPopupRed, noPopupAmber, confirmedChangeCount }
+noPopupRed      = boolean
+noPopupAmber    = boolean
 sync            = { autosync, lastModifiedLocally, basedOnRemoteLastModified, preferredOverRemoteLastModified }
 autosync        = boolean
 lastModifiedLocally             = number
@@ -631,7 +634,7 @@ results          = { *:* }
 closeProperty    = string
 onExit           = fn(*) => ()
 ```
-* `style` is an optional parameter to pass a custom CSS class name that is added to the modal so custom CSS styling can be applied using that class selector
+* `style` is an optional parameter to pass a custom CSS class name that is added to the modal so custom CSS styling can be applied using that class selector or if `style` contains any `:` it is not considered a CSS class name but as CSS properties as used in the `style` attribute of HTML elements
 * when a particular button is clicked the named `property` of that button is extracted from `results` and passed to `onExit` function. This value can be of any type and change while the dialog is open.
 * `closeProperty` is an optional field refering to the property used for the window close (x) button, if it is undefined the window has no such button
 
@@ -669,6 +672,7 @@ onRefreshSpeedChange = function (number) => ()
 
 
 ### FeedbackBanner API
+Component that shows a single feedback message.
 
 ```
 FEEDBACK_BANNER = { id, type, message }
@@ -676,11 +680,12 @@ id              = string
 type            = 'success' | 'error'
 message         = string
 ```
-* `message` is HTML
+* `message` is assumed HTML
 
 
 
 ### WidgetHeader API
+Component that is showing the widget title/caption/header and the "edit" or "settings" icon.
 
 ```
 WIDGET_HEADER    = { id, title, description, selected, onClick }
@@ -690,3 +695,18 @@ description      = string
 selected         = function () => boolean
 onClick          = function () => ()
 ```
+
+
+### AlertIndicator API
+Component that shows the global alerts summary at the bottom of the page
+
+```
+ALERTS_INDICATOR = { id, redAlerts, amberAlerts, changeCount }
+redAlerts        = ALERT_LEVEL
+amberAlerts      = ALERT_LEVEL
+ALERT_LEVEL      = { acknowledgedCount, unacknowledgedCount, color }
+color            = string
+acknowledgedCount   = number
+unacknowledgedCount = number
+```
+* `changeCount` increases each time the global alerts status has changed, meaning a new alert has started or an ongoing alert has stopped - this makes it easy to recognise such a change compared to a previous state

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -638,7 +638,7 @@ results          = { *:* }
 closeProperty    = string
 onExit           = fn(*) => ()
 ```
-* `style` is an optional parameter to pass a custom CSS class name that is added to the modal so custom CSS styling can be applied using that class selector or if `style` contains any `:` it is not considered a CSS class name but as CSS properties as used in the `style` attribute of HTML elements
+* `style` is an optional parameter to pass a custom CSS class name that is added to the modal so custom CSS styling can be applied using that class selector. If `style` contains any `:` it is not considered a CSS class name but as CSS properties as used in the `style` attribute of HTML elements
 * when a particular button is clicked the named `property` of that button is extracted from `results` and passed to `onExit` function. This value can be of any type and change while the dialog is open.
 * `closeProperty` is an optional field refering to the property used for the window close (x) button, if it is undefined the window has no such button
 

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -48,9 +48,6 @@ colors          = { *:COLOR }
 options         = { *:number }
 COLOR           = string
 role            = 'admin' | 'user' | 'guest'
-alerts          = { noPopupRed, noPopupAmber, confirmedChangeCount }
-noPopupRed      = boolean
-noPopupAmber    = boolean
 sync            = { autosync, lastModifiedLocally, basedOnRemoteLastModified, preferredOverRemoteLastModified }
 autosync        = boolean
 lastModifiedLocally             = number
@@ -62,6 +59,11 @@ maxSize         = number
 expires         = number
 ttl             = number
 filter          = 'line' | 'bar' | 'alert' | 'annotation' | 'rag' | undefined
+alerts          = { noPopupRed, noPopupAmber, confirmedChangeCount, confirmedSerials }
+noPopupRed      = boolean
+noPopupAmber    = boolean
+confirmedChangeCount = number
+confirmedSerials     = [ number ]
 ```
 * `id` is derived from `name` and used as attribute name in `pages` object
 * `widgets` can be omitted for an empty page
@@ -435,13 +437,14 @@ This component gives a tabular overview of alerts that occurred for the widget `
 ALERT_TABLE  = { id, verbose, items }
 brief        = boolean
 items        = [ ALERT_ITEM ]
-ALERT_ITEM   = { serial, name, series, instance, unit, color, acknowledged, frames, watch, annotations }
+ALERT_ITEM   = { serial, name, series, instance, unit, color, acknowledged, confirmed, frames, watch, annotations }
 serial       = number
 name         = string
 series       = string
 instance     = instance
 unit         = UNIT
 acknowledged = boolean
+confirmed    = boolean
 frames       = [ALERT_FRAME]
 ALERT_FRAME  = { level, since, until, color }
 level        = 'red' | 'amber'

--- a/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
@@ -103,7 +103,8 @@ public final class ApiResponses {
         public final int unacknowledgedAmberAlerts;
         public final int acknowledgedAmberAlerts;
         public final int watchCount;
-        public final int[] ongoingAlertSerials;
+        public final int[] ongoingRedAlerts;
+        public final int[] ongoingAmberAlerts;
 
         public Alerts(AlertStatistics stats) {
             this.watchCount = stats.watches;
@@ -112,7 +113,8 @@ public final class ApiResponses {
             this.acknowledgedRedAlerts = stats.acknowledgedRedAlerts;
             this.unacknowledgedAmberAlerts = stats.unacknowledgedAmberAlerts;
             this.acknowledgedAmberAlerts = stats.acknowledgedAmberAlerts;
-            this.ongoingAlertSerials = stats.ongoingAlertSerials;
+            this.ongoingRedAlerts = stats.ongoingRedAlerts;
+            this.ongoingAmberAlerts = stats.ongoingAmberAlerts;
         }
     }
 

--- a/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
@@ -102,13 +102,17 @@ public final class ApiResponses {
         public final int acknowledgedRedAlerts;
         public final int unacknowledgedAmberAlerts;
         public final int acknowledgedAmberAlerts;
+        public final int watchCount;
+        public final int[] ongoingAlertSerials;
 
         public Alerts(AlertStatistics stats) {
+            this.watchCount = stats.watches;
             this.changeCount = stats.changeCount;
             this.unacknowledgedRedAlerts = stats.unacknowledgedRedAlerts;
             this.acknowledgedRedAlerts = stats.acknowledgedRedAlerts;
             this.unacknowledgedAmberAlerts = stats.unacknowledgedAmberAlerts;
             this.acknowledgedAmberAlerts = stats.acknowledgedAmberAlerts;
+            this.ongoingAlertSerials = stats.ongoingAlertSerials;
         }
     }
 

--- a/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/MonitoringConsoleResource.java
@@ -39,13 +39,16 @@
  */
 package fish.payara.monitoring.web;
 
+import static java.lang.Integer.parseInt;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -82,6 +85,7 @@ import fish.payara.monitoring.adapt.MonitoringConsoleFactory;
 import fish.payara.monitoring.adapt.MonitoringConsolePageConfig;
 import fish.payara.monitoring.alert.Alert;
 import fish.payara.monitoring.alert.AlertService;
+import fish.payara.monitoring.alert.AlertService.AlertStatistics;
 import fish.payara.monitoring.alert.Circumstance;
 import fish.payara.monitoring.alert.Condition;
 import fish.payara.monitoring.alert.Condition.Operator;
@@ -324,8 +328,12 @@ public class MonitoringConsoleResource {
 
     @GET
     @Path("/alerts/data/{series}/")
-    public AlertsResponse getAlertsData(@PathParam("series") String series) {
-        return new AlertsResponse(alertService.alertsFor(seriesOrNull(series)));
+    public AlertsResponse getAlertsData(@PathParam("series") String seriesOrSerial) {
+        if (seriesOrSerial.matches("\\d+")) {
+            Alert alert = alertService.alertBySerial(parseInt(seriesOrSerial));
+            return new AlertsResponse(alert == null ? emptyList() : singletonList(alert));
+        }
+        return new AlertsResponse(alertService.alertsFor(seriesOrNull(seriesOrSerial)));
     }
 
     @POST

--- a/webapp/src/main/webapp/css/monitoring-console.css
+++ b/webapp/src/main/webapp/css/monitoring-console.css
@@ -350,7 +350,8 @@ button.toggle {
   line-height: inherit;
   padding: 2px;
   position: relative;
-  transform: none; 
+  transform: none;
+  margin-bottom: 2px;
 }
 button.toggle .toggle__off, 
 button.toggle .toggle__on {
@@ -605,6 +606,9 @@ svg.icon {
   padding-right: 0.5em;
   white-space: nowrap;
 }
+.Settings .toggle + label {
+  margin-left: 1em;
+}
 .Settings .x-input span {
   white-space: nowrap;
 }
@@ -807,11 +811,14 @@ table.tags th, table.tags td {
 
 /* Alert Tables */
 .AlertTable {
+  position: relative;
+  background-color: var(--widget-part-bg-color);
+}
+.widget .AlertTable {
   position: absolute;
   top: 40px;
   left: 15px;
   width: calc(100% - 38px);
-  background-color: var(--widget-part-bg-color);
   max-height: calc(100% - 110px);
   overflow-y: auto;
   overflow-x: hidden;  
@@ -864,6 +871,9 @@ table.tags th, table.tags td {
   border-width: 0 0 0 5px;
   padding: 0 5px;
   margin: 5px 0 0 0;
+}
+.widget .AlertTable .AlertTableUnconfirmed {
+  animation: blinker 1s cubic-bezier(0.68, -0.55, 0.27, 1.55) infinite;
 }
 
 

--- a/webapp/src/main/webapp/css/monitoring-console.css
+++ b/webapp/src/main/webapp/css/monitoring-console.css
@@ -849,6 +849,7 @@ table.tags th, table.tags td {
 .AlertTable .Item small {
   color: rgba(255,255,255,0.8);
   background-color: var(--widget-part-bg-color);
+  font-weight: normal;
 }
 .AlertTable .Item span {
   white-space: nowrap;

--- a/webapp/src/main/webapp/css/monitoring-console.css
+++ b/webapp/src/main/webapp/css/monitoring-console.css
@@ -205,7 +205,7 @@ footer {
   text-align: center;
   position: fixed;
   bottom: 0;
-  width: 100%;
+  width: calc(100% - 24px);
 }
 h1 {
 	font-size: 24px;
@@ -1461,3 +1461,30 @@ table.AnnotationTable {
 .ModalDialog .ModalDialogUserRole .ModalDialogButtons button {
   justify-self: center;
 }
+
+/* Alert Modal Dialog Customisation */
+#AlertDialog {
+  background: transparent;
+  pointer-events: none;
+}
+
+#AlertDialog .ModalDialogContent {
+  pointer-events: auto;
+}
+
+/* AlertIndicator Component */
+#AlertIndicator {
+  float: right;
+}
+.AlertIndicator a {
+  padding-left: 12px;
+  font-weight: bold;
+  text-decoration: none;
+}
+.AlertIndicator a b {
+  font-size: 24px;
+}
+.AlertIndicator a.AlertIndicatorActive {
+  animation: blinker 1s cubic-bezier(0.68, -0.55, 0.27, 1.55) infinite;
+}
+

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -49,15 +49,15 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=f"></script>
-    <link href="css/monitoring-console.css?x=f" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=g"></script>
+    <link href="css/monitoring-console.css?x=g" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 
+<div id="AlertDialog"></div>
 <div id="WatchSettingsModalDialog"></div>
 <div id="ModalDialog"></div>
 <div id="FeedbackBannerContainer"></div>
-<div id="AlertDialog"></div>
 
 <input type="file" id="cfgImport" accept=".json" style="display:none">
 

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -49,14 +49,15 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=e"></script>
-    <link href="css/monitoring-console.css?x=e" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=f"></script>
+    <link href="css/monitoring-console.css?x=f" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 
 <div id="WatchSettingsModalDialog"></div>
 <div id="ModalDialog"></div>
 <div id="FeedbackBannerContainer"></div>
+<div id="AlertDialog"></div>
 
 <input type="file" id="cfgImport" accept=".json" style="display:none">
 
@@ -70,7 +71,7 @@
   <aside id="Settings"></aside>
 </div>
 
-<footer class="page__footer">©2020 Payara Services Ltd.</footer>
+<footer class="page__footer">©2020 Payara Services Ltd. <aside id="AlertIndicator"/></footer>
 
 <script>
   MonitoringConsole.View.onPageReady();

--- a/webapp/src/main/webapp/js/mc-controller.js
+++ b/webapp/src/main/webapp/js/mc-controller.js
@@ -47,169 +47,187 @@
  **/
 MonitoringConsole.Controller = (function() {
 
-   function requestWithJsonBody(method, url, queryData, onSuccess, onFailure) {
-      $.ajax({
-         url: url,
-         type: method,
-         data: JSON.stringify(queryData),
-         contentType:"application/json; charset=utf-8",
-         dataType:"json",
-      }).done(onSuccess).fail(onFailure);
-   }
+  function requestWithJsonBody(method, url, queryData, onSuccess, onFailure) {
+    $.ajax({
+       url: url,
+       type: method,
+       data: JSON.stringify(queryData),
+       contentType:"application/json; charset=utf-8",
+       dataType:"json",
+    }).done(onSuccess).fail(onFailure);
+  }
 
-   function requestWithoutBody(method, url, onSuccess, onFailure) {
-      $.ajax({ type: method, url: url }).done(onSuccess).fail(onFailure);
-   }
+  function requestWithoutBody(method, url, onSuccess, onFailure) {
+    $.ajax({ type: method, url: url }).done(onSuccess).fail(onFailure);
+  }
 
-   function requestJSON(url, onSuccess, onFailure) {
-      $.getJSON(url, onSuccess).fail(onFailure);
-   }
+  function requestJSON(url, onSuccess, onFailure) {
+    $.getJSON(url, onSuccess).fail(onFailure);
+  }
 
-   /**
-    * @param {array|object} queries   - a JS array with query objects as expected by the server API (object corresponds to java class SeriesQuery)
-    *                                   or a JS object corresponding to java class SeriesRequest
-    * @param {function}     onSuccess - a callback function with one argument accepting the response object as send by the server (java class SeriesResponse)
-    * @param {function}     onFailure - a callback function with no arguments
-    */
-   function requestListOfSeriesData(queries, onSuccess, onFailure) {
-      const request = !Array.isArray(queries) ? queries : { queries: queries }; 
-      requestWithJsonBody('POST', 'api/series/data/', request, onSuccess, onFailure);
-   }
+  /**
+  * @param {array|object} queries   - a JS array with query objects as expected by the server API (object corresponds to java class SeriesQuery)
+  *                                   or a JS object corresponding to java class SeriesRequest
+  * @param {function}     onSuccess - a callback function with one argument accepting the response object as send by the server (java class SeriesResponse)
+  * @param {function}     onFailure - a callback function with no arguments
+  */
+  function requestListOfSeriesData(queries, onSuccess, onFailure) {
+    const request = !Array.isArray(queries) ? queries : { queries: queries }; 
+    requestWithJsonBody('POST', 'api/series/data/', request, onSuccess, onFailure);
+  }
 
-   /**
-    * @param {function} onSuccess - a function with one argument accepting an array of series names
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestListOfSeriesNames(onSuccess, onFailure) {
-      requestJSON("api/series/", onSuccess, onFailure);
-   }
+  /**
+  * @param {function} onSuccess - a function with one argument accepting an array of series names
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestListOfSeriesNames(onSuccess, onFailure) {
+    requestJSON("api/series/", onSuccess, onFailure);
+  }
 
-   /**
-    * @param {string}   series    - name of the metric series
-    * @param {function} onSuccess - a function with one argument accepting an array request traces as returned by the server (each trace object corresponds to java class RequestTraceResponse)
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestListOfRequestTraces(series, onSuccess, onFailure) {
-      requestJSON("api/trace/data/" + series, onSuccess, onFailure);
-   }
+  /**
+  * @param {string}   series    - name of the metric series
+  * @param {function} onSuccess - a function with one argument accepting an array request traces as returned by the server (each trace object corresponds to java class RequestTraceResponse)
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestListOfRequestTraces(series, onSuccess, onFailure) {
+    requestJSON("api/trace/data/" + series, onSuccess, onFailure);
+  }
 
-   /**
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestListOfWatches(onSuccess, onFailure) {
-      requestJSON("api/watches/data/", (response) => onSuccess(response.watches), onFailure);
-   }
+  /**
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestListOfWatches(onSuccess, onFailure) {
+    requestJSON("api/watches/data/", (response) => onSuccess(response.watches), onFailure);
+  }
 
-   /**
-    * @param {object}   watch     - a JS watch object as expected by the server API (object corresponds to java class WatchData)
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestCreateWatch(watch, onSuccess, onFailure) {
-      requestWithJsonBody('PUT', 'api/watches/data/', watch, onSuccess, onFailure);
-   }
+  /**
+  * @param {object}   watch     - a JS watch object as expected by the server API (object corresponds to java class WatchData)
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestCreateWatch(watch, onSuccess, onFailure) {
+    requestWithJsonBody('PUT', 'api/watches/data/', watch, onSuccess, onFailure);
+  }
 
-   /**
-    * @param {string}   name      - name of the watch to delete
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestDeleteWatch(name, onSuccess, onFailure) {
-      requestWithoutBody('DELETE', 'api/watches/data/' + name + '/', onSuccess, onFailure);
-   }
+  /**
+  * @param {string}   name      - name of the watch to delete
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestDeleteWatch(name, onSuccess, onFailure) {
+    requestWithoutBody('DELETE', 'api/watches/data/' + name + '/', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {string}   name      - name of the watch to disable
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestDisableWatch(name, onSuccess, onFailure) {
-      requestWithoutBody('PATCH', 'api/watches/data/' + name + '/?disable=true', onSuccess, onFailure);
-   }
+  /**
+  * @param {string}   name      - name of the watch to disable
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestDisableWatch(name, onSuccess, onFailure) {
+    requestWithoutBody('PATCH', 'api/watches/data/' + name + '/?disable=true', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {string}   name      - name of the watch to enable
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestEnableWatch(name, onSuccess, onFailure) {
-      requestWithoutBody('PATCH', 'api/watches/data/' + name + '/?disable=false', onSuccess, onFailure);
-   }
+  /**
+  * @param {string}   name      - name of the watch to enable
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestEnableWatch(name, onSuccess, onFailure) {
+    requestWithoutBody('PATCH', 'api/watches/data/' + name + '/?disable=false', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {number}   serial    - serial of the alert to ackknowledge
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestAcknowledgeAlert(serial, onSuccess, onFailure) {
-      requestWithoutBody('POST', 'api/alerts/ack/' + serial + '/', onSuccess, onFailure);
-   }
+  /**
+  * @param {number}   serial    - serial of the alert to ackknowledge
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestAcknowledgeAlert(serial, onSuccess, onFailure) {
+    requestWithoutBody('POST', 'api/alerts/ack/' + serial + '/', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {object}   page      - a JS page object as defined and used by the UI
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestUpdateRemotePage(page, onSuccess, onFailure) {
-      requestWithJsonBody('PUT', 'api/pages/data/' + page.id + '/', page, onSuccess, onFailure);
-   }
+  /**
+  * @param {object}   page      - a JS page object as defined and used by the UI
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestUpdateRemotePage(page, onSuccess, onFailure) {
+    requestWithJsonBody('PUT', 'api/pages/data/' + page.id + '/', page, onSuccess, onFailure);
+  }
 
-   /**
-    * @param {string}   pageId    - ID of the page to delete
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestDeleteRemotePage(pageId, onSuccess, onFailure)  {
-      requestWithoutBody('DELETE', 'api/pages/data/' + pageId + '/', onSuccess, onFailure);
-   }
+  /**
+  * @param {string}   pageId    - ID of the page to delete
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestDeleteRemotePage(pageId, onSuccess, onFailure)  {
+    requestWithoutBody('DELETE', 'api/pages/data/' + pageId + '/', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {string}   pageId    - ID of the page to get from server
-    * @param {function} onSuccess - a function with one argument accepting an array request traces as returned by the server (each trace object corresponds to java class RequestTraceResponse)
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestRemotePage(pageId, onSuccess, onFailure) {
-      requestJSON('api/pages/data/' + pageId + '/', onSuccess, onFailure);
-   }
+  /**
+  * @param {string}   pageId    - ID of the page to get from server
+  * @param {function} onSuccess - a function with one argument accepting an array request traces as returned by the server (each trace object corresponds to java class RequestTraceResponse)
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestRemotePage(pageId, onSuccess, onFailure) {
+    requestJSON('api/pages/data/' + pageId + '/', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {function} onSuccess - a callback function with no arguments
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestListOfRemotePages(onSuccess, onFailure) {
-      requestJSON('api/pages/data/', onSuccess, onFailure);
-   }
+  /**
+  * @param {function} onSuccess - a callback function with no arguments
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestListOfRemotePages(onSuccess, onFailure) {
+    requestJSON('api/pages/data/', onSuccess, onFailure);
+  }
 
-   /**
-    * @param {function} onSuccess - a function with one argument accepting an array of page names
-    * @param {function} onFailure - a callback function with no arguments
-    */
-   function requestListOfRemotePageNames(onSuccess, onFailure) {
-      requestJSON("api/pages/", onSuccess, onFailure);
-   }
+  /**
+  * @param {function} onSuccess - a function with one argument accepting an array of page names
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestListOfRemotePageNames(onSuccess, onFailure) {
+    requestJSON("api/pages/", onSuccess, onFailure);
+  }
 
-   /**
-    * Public API to talk to the server.
-    * 
-    * Note that none of the functions have a direct return value.
-    * All function "return" data by calling their "onSuccess" callback with the result
-    * or the "onFailure" callback in case the equest failed.
-    */ 
-   return {
-      requestListOfSeriesData: requestListOfSeriesData,
-      requestListOfSeriesNames: requestListOfSeriesNames,
-      requestListOfRequestTraces: requestListOfRequestTraces,
-      requestListOfWatches: requestListOfWatches,
-      requestCreateWatch: requestCreateWatch,
-      requestDeleteWatch: requestDeleteWatch,
-      requestDisableWatch: requestDisableWatch,
-      requestEnableWatch: requestEnableWatch,
-      requestAcknowledgeAlert: requestAcknowledgeAlert,
-      requestUpdateRemotePage: requestUpdateRemotePage,
-      requestDeleteRemotePage: requestDeleteRemotePage,
-      requestRemotePage: requestRemotePage,
-      requestListOfRemotePages: requestListOfRemotePages,
-      requestListOfRemotePageNames: requestListOfRemotePageNames,
-   };
+  /**
+  * @param {function} onSuccess - a function with one argument accepting an array of page names
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestListOfAlerts(onSuccess, onFailure) {
+    requestJSON("api/alerts/data/", onSuccess, onFailure);
+  }
+
+  /**
+  * @param {function} onSuccess - a function with one argument accepting an array of page names
+  * @param {function} onFailure - a callback function with no arguments
+  */
+  function requestAlertDetails(serial, onSuccess, onFailure) {
+    requestJSON(`api/alerts/data/${serial}/`, onSuccess, onFailure);
+  }
+
+  /**
+  * Public API to talk to the server.
+  * 
+  * Note that none of the functions have a direct return value.
+  * All function "return" data by calling their "onSuccess" callback with the result
+  * or the "onFailure" callback in case the equest failed.
+  */ 
+  return {
+    requestListOfSeriesData: requestListOfSeriesData,
+    requestListOfSeriesNames: requestListOfSeriesNames,
+    requestListOfRequestTraces: requestListOfRequestTraces,
+    requestListOfWatches: requestListOfWatches,
+    requestCreateWatch: requestCreateWatch,
+    requestDeleteWatch: requestDeleteWatch,
+    requestDisableWatch: requestDisableWatch,
+    requestEnableWatch: requestEnableWatch,
+    requestAcknowledgeAlert: requestAcknowledgeAlert,
+    requestUpdateRemotePage: requestUpdateRemotePage,
+    requestDeleteRemotePage: requestDeleteRemotePage,
+    requestRemotePage: requestRemotePage,
+    requestListOfRemotePages: requestListOfRemotePages,
+    requestListOfRemotePageNames: requestListOfRemotePageNames,
+    requestListOfAlerts: requestListOfAlerts,
+    requestAlertDetails: requestAlertDetails,
+  };
 })();

--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -175,6 +175,8 @@ MonitoringConsole.Model = (function() {
 				settings.rotation = {};
 			if (typeof settings.rotation.interval !== 'number')
 				settings.rotation.interval = 60;
+			if (typeof settings.alerts !== 'object')
+				settings.alerts = {};
 			return settings;
 		}
 		
@@ -855,6 +857,29 @@ MonitoringConsole.Model = (function() {
 				doStore();
 			},
 
+			Alerts: {
+				showPopupRed: function(showPopup) {
+					if (showPopup === undefined)
+						return settings.alerts.noPopupRed !== true;
+					settings.alerts.noPopupRed = showPopup !== true;
+					doStore();
+				},
+
+				showPopupAmber: function(showPopup) {
+					if (showPopup === undefined)
+						return settings.alerts.noPopupAmber !== true;
+					settings.alerts.noPopupAmber = showPopup !== true;
+					doStore();
+				},				
+
+				confirm: function(changeCount) {
+					settings.alerts.confirmedChangeCount = settings.alerts.confirmedChangeCount === undefined ? changeCount : Math.max(settings.alerts.confirmedChangeCount, changeCount);
+					doStore();
+				},
+
+				confirmed: () => settings.alerts.confirmedChangeCount || 0,
+			},
+
 			Navigation: {
 				isCollapsed: () => settings.nav.collapsed === true,
 				isExpanded: () => settings.nav.collapsed !== true,
@@ -1286,6 +1311,9 @@ MonitoringConsole.Model = (function() {
 						chart: () => Charts.getOrCreate(widget),
 					});
 				});
+				// by convention the same function is called for global updates 
+				// in that case it does not have a widget property but just the below:
+				onDataUpdate({ alerts: response.alerts });
 			};
 		}
 
@@ -1476,6 +1504,8 @@ MonitoringConsole.Model = (function() {
 			open: UI.openSettings,
 			close: UI.closeSettings,
 			toggle: () => UI.showSettings() ? UI.closeSettings() : UI.openSettings(),
+
+			Alerts: UI.Alerts,
 
 			Rotation: {
 				isEnabled: UI.Rotation.isEnabled,

--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -858,31 +858,26 @@ MonitoringConsole.Model = (function() {
 			},
 
 			Alerts: {
-				showPopupRed: function(showPopup) {
+				showPopup: function(showPopup) {
 					if (showPopup === undefined)
-						return settings.alerts.noPopupRed !== true;
-					settings.alerts.noPopupRed = showPopup !== true;
+						return settings.alerts.noPopup !== true;
+					settings.alerts.noPopup = showPopup !== true;
 					doStore();
-				},
+				},			
 
-				showPopupAmber: function(showPopup) {
-					if (showPopup === undefined)
-						return settings.alerts.noPopupAmber !== true;
-					settings.alerts.noPopupAmber = showPopup !== true;
-					doStore();
-				},				
-
-				confirm: function(changeCount, serials) {
-					const currentChangeCount = settings.alerts.confirmedChangeCount;
-					if (currentChangeCount === undefined || changeCount > currentChangeCount) {
-						settings.alerts.confirmedChangeCount = changeCount;
-						settings.alerts.confirmedSerials = serials;
+				confirm: function(changeCount, redAlerts, amberAlerts) {
+					if (settings.alerts.confirmed === undefined || changeCount > settings.alerts.confirmed.changeCount) {
+						settings.alerts.confirmed = { changeCount, redAlerts, amberAlerts };
 						doStore();
 					}
 				},
 
-				confirmed: () => settings.alerts.confirmedChangeCount || 0,
-				confirmedSerials: () => settings.alerts.confirmedSerials || [],
+				confirmedChangeCount: () => settings.alerts.confirmed === undefined ? -1 : settings.alerts.confirmed.changeCount,
+				confirmedRedAlerts: () => settings.alerts.confirmed === undefined ? [] : settings.alerts.confirmed.redAlerts,
+				confirmedAmberAlerts: () => settings.alerts.confirmed === undefined ? [] : settings.alerts.confirmed.amberAlerts,
+				confirmedSerials: () => settings.alerts.confirmed === undefined 
+					? [] 
+					: settings.alerts.confirmed.redAlerts.concat(settings.alerts.confirmed.amberAlerts),
 			},
 
 			Navigation: {

--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -873,11 +873,8 @@ MonitoringConsole.Model = (function() {
 				},
 
 				confirmedChangeCount: () => settings.alerts.confirmed === undefined ? -1 : settings.alerts.confirmed.changeCount,
-				confirmedRedAlerts: () => settings.alerts.confirmed === undefined ? [] : settings.alerts.confirmed.redAlerts,
-				confirmedAmberAlerts: () => settings.alerts.confirmed === undefined ? [] : settings.alerts.confirmed.amberAlerts,
-				confirmedSerials: () => settings.alerts.confirmed === undefined 
-					? [] 
-					: settings.alerts.confirmed.redAlerts.concat(settings.alerts.confirmed.amberAlerts),
+				confirmedRedAlerts: () => settings.alerts.confirmed === undefined ? [] : settings.alerts.confirmed.redAlerts || [],
+				confirmedAmberAlerts: () => settings.alerts.confirmed === undefined ? [] : settings.alerts.confirmed.amberAlerts || [],
 			},
 
 			Navigation: {
@@ -1402,7 +1399,8 @@ MonitoringConsole.Model = (function() {
 			}
 			let widgets = page.widgets;
 			Controller.requestListOfSeriesData(Update.createQuery(widgets), 
-				Update.createOnSuccess(widgets, onDataUpdate, UI.Alerts.confirmedSerials),
+				Update.createOnSuccess(widgets, onDataUpdate, 
+					() => UI.Alerts.confirmedRedAlerts().concat(UI.Alerts.confirmedAmberAlerts())),
 				Update.createOnError(widgets, onDataUpdate));
 		});
 		if (UI.Refresh.interval() === undefined) {

--- a/webapp/src/main/webapp/js/mc-view-components.js
+++ b/webapp/src/main/webapp/js/mc-view-components.js
@@ -1582,7 +1582,8 @@ MonitoringConsole.View.Components = (function() {
       };
       const overlay = $('<div/>', config);
       const dialog = $('<div/>', {
-        class: `ModalDialogContent${(model.style ? ' ' +  model.style : '')}`,
+        class: `ModalDialogContent${(model.style && !model.style.includes(':') ? ' ' +  model.style : '')}`,
+        style: model.style && model.style.includes(':') ? model.style : undefined,
       });
       if (model.title !== undefined && model.title != '')
         dialog.append($('<h2/>').html(model.title));
@@ -1832,6 +1833,47 @@ MonitoringConsole.View.Components = (function() {
   })();
 
 
+  /**
+   * AlertIndicator is the global alerts summary shown at the botton of the page (footer)
+   */ 
+  const AlertIndicator = (function() {
+
+    function createComponent(model) {
+      const config = { class: 'AlertIndicator'};
+      if (model.id)
+        config.id = model.id;
+      addTotal(model.redAlerts);
+      addTotal(model.amberAlerts);
+      if (model.redAlerts.totalCount == 0 && model.amberAlerts.totalCount == 0) {
+        model.class += ' AlertIndicatorNoAlerts';
+      }
+      const indicator = $('<aside/>', config);
+      if (model.redAlerts.totalCount > 0) {
+        indicator.append($('<a/>', { 
+          style: `color: ${model.redAlerts.color};`,
+          class: model.redAlerts.unacknowledgedCount > 0 ? 'AlertIndicatorActive' : undefined,
+          title: `${model.redAlerts.unacknowledgedCount} unacknowledged ongoing red alerts (${model.redAlerts.acknowledgedCount} acknowledged)`,
+          href: '#alerts',
+        }).html(`<b>&#x26a0;</b> ${model.redAlerts.unacknowledgedCount} <small>(${model.redAlerts.acknowledgedCount})</small>`));
+      }
+      if (model.amberAlerts.totalCount > 0) {
+        indicator.append($('<a/>', { 
+          style: `color: ${model.amberAlerts.color};`,
+          class: model.amberAlerts.unacknowledgedCount > 0 ? 'AlertIndicatorActive' : undefined,
+          title: `${model.amberAlerts.unacknowledgedCount} unacknowledged ongoing amber alerts (${model.amberAlerts.acknowledgedCount} acknowledged)`,
+          href: '#alerts',
+        }).html(`<b>&#x26a0;</b> ${model.amberAlerts.unacknowledgedCount} <small>(${model.amberAlerts.acknowledgedCount})</small>`));        
+      }
+      return indicator;
+    }
+
+    function addTotal(level) {
+      level.totalCount = level.acknowledgedCount + level.unacknowledgedCount;
+    }
+
+    return { createComponent: createComponent };
+  })();
+
   /*
    * Shared functions
    */
@@ -1903,6 +1945,7 @@ MonitoringConsole.View.Components = (function() {
       createNavSidebar: model => NavSidebar.createComponent(model),
       createFeedbackBanner: model => FeedbackBanner.createComponent(model),
       createWidgetHeader: model => WidgetHeader.createComponent(model),
+      createAlertIndicator: model => AlertIndicator.createComponent(model),
       createIconButton: model => createIconButton(model),
   };
 

--- a/webapp/src/main/webapp/js/mc-view-components.js
+++ b/webapp/src/main/webapp/js/mc-view-components.js
@@ -711,7 +711,11 @@ MonitoringConsole.View.Components = (function() {
         box.append(createConditionGroup(item));
       if (verbose && Array.isArray(item.annotations) && item.annotations.length > 0)
         box.append(createAnnotationGroup(item));
-      let row = $('<div/>', { id: `Alert-${item.serial}` , class: `Item ${level}` , style: `border-color: ${item.color};` });
+      let row = $('<div/>', { 
+        id: `Alert-${item.serial}`, 
+        class: `Item ${level} ${item.confirmed ? 'AlertTableConfirmed' : ongoing ? 'AlertTableUnconfirmed' : ''}`, 
+        style: `border-color: ${item.color};`,
+      });
       row.append(box);
       return row;
     }

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -512,7 +512,9 @@ MonitoringConsole.View = (function() {
 
     function showModalDialog(model) {
         const id = model.id || 'ModalDialog';
-        $('#' + id).replaceWith(Components.createModalDialog(model));
+        const dialog = Components.createModalDialog(model);
+        $('#' + id).replaceWith(dialog);
+        return dialog;
     }
 
     function showFeedback(model) {
@@ -1369,14 +1371,18 @@ MonitoringConsole.View = (function() {
         const showPopup = MonitoringConsole.Model.Settings.Alerts.showPopup();
         const confirm = () => MonitoringConsole.Model.Settings.Alerts.confirm(alerts.changeCount, alerts.ongoingRedAlerts, alerts.ongoingAmberAlerts);
         if (showPopup && !isConfirmed) {
+            // test: is there already a popup for the current change-count? => done
+            const shownDialog = $('#AlertDialog');
+            if (shownDialog.attr('data-change-count') == alerts.changeCount)
+                return; // we already show the proper popup - do not change it (save potential server requests to fetch alert data)
             const content = await createGlobalAlertContent(alerts);
-            showModalDialog({
+            const dialog = showModalDialog({
                 id: 'AlertDialog',
                 title: 'Alert Status Change',
                 content: content,
                 buttons: [
-                    { property: 'confirm', label: 'Confirm', secondary: true },
-                    { property: 'show', label: 'Confirm & Show', secondary: true },
+                    { property: 'confirm', label: 'OK' },
+                    { property: 'show', label: 'Show', secondary: true },
                 ],
                 results: { confirm: false, show: true },
                 closeProperty: 'confirm',
@@ -1388,6 +1394,7 @@ MonitoringConsole.View = (function() {
                     }
                 }                
             });
+            dialog.attr('data-change-count', alerts.changeCount);
         } else {
             $('#AlertDialog').hide();
             if (!showPopup || alerts.changeCount + 1000 < lastConfirmed) // most likely a server restart after new year 

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -1308,6 +1308,11 @@ MonitoringConsole.View = (function() {
      * Depending on the update different content is rendered within a chart box.
      */
     function onDataUpdate(update) {
+        function replaceKeepYScroll(replaced, replacement) {
+            const top = replaced.scrollTop();
+            replaced.replaceWith(replacement);
+            replacement.scrollTop(top);
+        }
         if (update.widget === undefined) {
             onGlobalUpdate(update);
             return;
@@ -1329,17 +1334,17 @@ MonitoringConsole.View = (function() {
         if (data !== undefined && (widget.type === 'line' || widget.type === 'bar')) {
             MonitoringConsole.Chart.getAPI(widget).onDataUpdate(update);
         }
-        headerNode.replaceWith(Components.createWidgetHeader(createWidgetHeaderModel(widget)));
+        replaceKeepYScroll(headerNode, Components.createWidgetHeader(createWidgetHeaderModel(widget)));
         if (widget.type == 'rag') {
             alertsNode.hide();
             legendNode.hide();
-            indicatorNode.replaceWith(Components.createRAGIndicator(createRAGIndicatorModel(widget, legend)));
+            replaceKeepYScroll(indicatorNode, Components.createRAGIndicator(createRAGIndicatorModel(widget, legend)));
             annotationsNode.hide();
         } else {
-            alertsNode.replaceWith(Components.createAlertTable(createAlertTableModel(widget, alerts, annotations)));
-            legendNode.replaceWith(Components.createLegend(legend));
-            indicatorNode.replaceWith(Components.createIndicator(createIndicatorModel(widget, data)));
-            annotationsNode.replaceWith(Components.createAnnotationTable(createAnnotationTableModel(widget, annotations)));            
+            replaceKeepYScroll(alertsNode, Components.createAlertTable(createAlertTableModel(widget, alerts, annotations)));
+            replaceKeepYScroll(legendNode, Components.createLegend(legend));
+            replaceKeepYScroll(indicatorNode, Components.createIndicator(createIndicatorModel(widget, data)));
+            replaceKeepYScroll(annotationsNode, Components.createAnnotationTable(createAnnotationTableModel(widget, annotations)));            
         }
     }
 
@@ -1429,8 +1434,8 @@ MonitoringConsole.View = (function() {
         // basis sets
         const redConfirmed = MonitoringConsole.Model.Settings.Alerts.confirmedRedAlerts();
         const amberConfirmed = MonitoringConsole.Model.Settings.Alerts.confirmedAmberAlerts();
-        const redCurrent = alerts.ongoingRedAlerts;
-        const amberCurrent = alerts.ongoingAmberAlerts;
+        const redCurrent = alerts.ongoingRedAlerts || [];
+        const amberCurrent = alerts.ongoingAmberAlerts || [];
         const allConfirmed = union(redConfirmed, amberConfirmed);
         const allCurrent = union(redCurrent, amberCurrent);
         // transition sets

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -1382,8 +1382,10 @@ MonitoringConsole.View = (function() {
                 closeProperty: 'confirm',
                 onExit: show => {
                     confirm();
-                    if (show)
+                    if (show) {
+                        MonitoringConsole.Model.Settings.Rotation.enabled(false);
                         onPageChange(MonitoringConsole.Model.Page.changeTo('alerts'));
+                    }
                 }                
             });
         } else {


### PR DESCRIPTION
### Summary
Goal of this PR is to add "global" alert feedback to Payara InSight. 
This means a user can/will notice all alerts independent of the page currently shown.
This is approached in two ways, one more discreet and another one more right in your face.

**The discrete** is a alert status indicator in the footer that gives a summary of all alerts in form of numbers. Clicking on the indicator opens the _Alerts_ page where any ongoing alert (which these are) will be shown.

![mc_footer-alerts](https://user-images.githubusercontent.com/309438/96894315-e2063780-148b-11eb-8e01-80c81c799400.png)

**The persistent** is an alert status change popup which automatically pops up the moment an alert status change occurs.
It details the changes and shows the alert details.

![screenshot-localhost_8080-2020 10 22-17_26_41](https://user-images.githubusercontent.com/309438/96894625-0d892200-148c-11eb-8d4a-2ec8e99b6b5b.png)
 
The persistent one can be disabled by a new toggle settings in _Application_ settings tab _Alerts_; by default it is _On_.

![mc_settings_app_alerts-h](https://user-images.githubusercontent.com/309438/96895042-44f7ce80-148c-11eb-8b48-861929459077.png)

I also sneaked in a fix for the issue that scroll state would be lost due to update being applied to the component.
This now allows to go through lists of alerts without having the scroll jump to the top after 2 seconds (poll interval). :space_invader: 

### Design Decisions
Some decisions made when designing the new feature:

* **Alert Status Change popup is layered below other popups.** For example when being in the watches settings while an alert status change occurs the change is first encountered when the settings popup is closed. Reasoning: It would be too annoying otherwise
* **Alert Status Change popup is _not_ modal.** That means you can click on stuff in the background and the overlay is not greying out content outside of the dialog. Reasoning: It makes sense to be able to clearly see and even use what is on the page while seeing the popup on top. Technically this is still the same modal dialog just that overlay color is changed and it does not capture click events.
* **Transitions from _Healthy_ and _Normal_ are both shown as transitions from _Healthy_**. Reasoning: It is simpler and more clear to have less combinations (of state transitions) and for alerts it does not matter if the previous state was _Healthy_ or _Normal_, those are one group in that context.
* **Clicking _Show_ in the popup which navigates to the _Alerts_ page will also stop any ongoing page rotation.** Reasoning: As the user has the intention to now look at the alerts continuing rotation makes little sense
* **The alert indicator flashes whenever there are unacknowledged alerts.** Reasoning: This is usually when you are not aware of the alerts so attention should be drawn to the alerts, so they flash

### Technical Details
The alerts summary used to update the alert indicator has always been part of the response when polling data for the current page. This means there is no extra request and pages continue to only use a single request to poll data to update the page.
The payload has been extended slightly now also containing the serial numbers of the currently ongoing alerts which is considered a small set.

When alert details are shown as part of the status change popup this information potentially needs to be loaded from the server. But it might be included in the alerts attached to widget on the page. If so this information will be used and no extra requests are done. If the alert details needed are not present they are loaded by serial number creating one request per alert details. To prevent this from happening each time the page is updated in polling interval a check is added that can tell if the popup potentially already included in the page (from last update) already shows the correct popup. In that case the popup is just left untouched and no extra server requests are needed until the status actually changes again. If a change occurred can easily be identified by the change counter included in the alerts statistics. 

**TLDR;** Even with new feature we still just do single poll request, extra requests are avoided where possible and only occur once when needed until next actual status change.

### Testing
#### Setup
* Build InSight (all modules)
* copy `process` module to `glassfish/modules` folder
* deploy `webapp` module manually

(or do a full server build with updates references to InSight SNAPSHOT versions)

#### Testing Performed
* enable Payara Health Check for Machine Memory Usage
* configure warning threshold so that current usage will be triggered
* open InSight and wait for the popup informing about the status change, press ok or show
* disable the health check
* check in InSight another popup informs about the change, press ok or show
* re-enable the health check and check again for the popup
* repeat the above without pressing ok or show when popup occurs and check the popup updates with the changes to health check
* configure health check so critical threshold is exceeded and check status change is given by the popup
* disable popups in the _Application_ => tab _Alerts_ => _ property _Popups_ setting
* cause some alert status changes and check the alert indicator in the bottom right of the footer updates accordingly
* acknowledge an alert and check the alert indicator updates accordingly

Also I tested with an app including MP health checks which cause watches and alerts should the health check compute to status _DOWN_. 

* enable page rotation and repeat some of the testing to verify that the popup is shown even while rotating through the pages
* press _Show_ in the popup while pages rotate and check rotation stops after jumping to the _Alerts_ page

### Documentation
https://github.com/payara/Payara-Enterprise-Documentation/pull/68