### PR TITLE
FISH-755 Payara InSight 1.6

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.6</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.6</version>
+        <version>1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.6</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.6</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.6</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.6</version>
+        <version>1.7-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.6</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.6</version>
+        <version>1.7-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>


### PR DESCRIPTION
Includes #28 

Release of implementation only (modules `process`, `webapp`), `api` is not released and hence stays at a snapshot version.

Use of 1.6 in Payara Enterprise in https://github.com/payara/Payara-Enterprise/pull/239