### PR TITLE
FISH-752 Aggregated History (Sliding Windows)

### DIFF
--- a/api/src/main/java/fish/payara/monitoring/adapt/MonitoringConsole.java
+++ b/api/src/main/java/fish/payara/monitoring/adapt/MonitoringConsole.java
@@ -44,11 +44,11 @@ import java.util.NoSuchElementException;
 /**
  * The {@link MonitoringConsole} is the control interface for the logical processing instance running on each node in a
  * cluster. A {@link MonitoringConsole} can be one of the senders of the cluster or the single receiver of the cluster.
- * 
+ *
  * The interface allows the monitored application to control the console state.
- * 
+ *
  * The instance is created by the {@link MonitoringConsoleFactory}. It is implemented by the monitoring console library.
- * 
+ *
  * @author Jan Bernitt
  * @since 1.0 (Payara 5.201)
  */
@@ -57,14 +57,25 @@ public interface MonitoringConsole {
     /**
      * When enabled the console does its data collection and sends it data to the receiver instance (as sender) or
      * stores it (as receiver).
-     * 
+     *
      * @param enabled true to enable the console, false to disable it
      */
     void setEnabled(boolean enabled);
 
     /**
+     * When enabled the console aggregates collected data to build a history over time. This requires extra memory. When
+     * this feature is disabled and data is still collected (updated) the history build so far is cleared and the memory
+     * freed.
+     *
+     * @since 1.2
+     *
+     * @param enabled true to start recording aggregate data, false to disable and remove aggregate data
+     */
+    void setHistoryEnabled(boolean enabled);
+
+    /**
      * Simple service locator to access abstractions within the console.
-     * 
+     *
      * @param type an interface type for the service to load
      * @return the service instance
      * @throws NoSuchElementException in case no service of type is known

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>fish.payara.monitoring-console</groupId>
             <artifactId>monitoring-console-api</artifactId>
-            <version>1.1</version>
+            <version>1.2-SNAPSHOT</version>
         </dependency>
 
         <!-- The below dependencies are expected to be provided by the monitored application -->

--- a/process/src/main/java/fish/payara/monitoring/internal/adapt/MonitoringConsoleImpl.java
+++ b/process/src/main/java/fish/payara/monitoring/internal/adapt/MonitoringConsoleImpl.java
@@ -121,6 +121,11 @@ public class MonitoringConsoleImpl implements MonitoringConsole, MonitoringDataS
         alerts.setEnabled(enabled);
     }
 
+    @Override
+    public void setHistoryEnabled(boolean enabled) {
+        data.setHistoryEnabled(enabled);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getService(Class<T> type) throws NoSuchElementException {

--- a/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
@@ -1,10 +1,12 @@
 package fish.payara.monitoring.model;
 
+import static java.lang.System.arraycopy;
+
 public abstract class AggregateDataset<T extends AggregateDataset<T>> {
 
-    protected final long[] mins;
-    protected final long[] maxs;
-    protected final double[] avgs;
+    private final long[] mins;
+    private final long[] maxs;
+    private final double[] avgs;
     protected final int[] points;
     protected final long firstTime;
     /**
@@ -14,17 +16,32 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
     protected final int offset;
     protected int length;
 
-    public  AggregateDataset(int maxLength) {
-        this.mins = new long[maxLength];
-        this.maxs = new long[maxLength];
-        this.avgs = new double[maxLength];
-        this.points = new int[maxLength];
+    /**
+     * Used to create a new empty dataset.
+     *
+     * @param capacity the initial capacity that should be equal to the number of points in the interval, for example 60
+     *                 for minutes in an hour
+     */
+    protected AggregateDataset(int capacity) {
+        this.mins = new long[capacity];
+        this.maxs = new long[capacity];
+        this.avgs = new double[capacity];
+        this.points = new int[capacity];
         this.firstTime = -1L;
         this.offset = 0;
         this.length = 0;
     }
 
-    public AggregateDataset(AggregateDataset<T> predecessor, int offset, long firstTime) {
+    /**
+     * Used when appending a new point to a dataset of initial capacity.
+     *
+     * @param predecessor The dataset which has 1 datapoint less than this will have
+     * @param offset      the offset of this dataset; this is the same as the one of the predecessor (if set) or the one
+     *                    of the first datapoint
+     * @param firstTime   the first time of this dataset; this is the same as the one of the predecessor (if set) or the
+     *                    one of the first datapoint
+     */
+    protected AggregateDataset(AggregateDataset<T> predecessor, int offset, long firstTime) {
         this.mins = predecessor.mins;
         this.maxs = predecessor.maxs;
         this.avgs = predecessor.avgs;
@@ -35,7 +52,58 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
     }
 
     /**
-     * @param index 0-59
+     * Used when copying a section of the base dataset as a basis for a new sliding window dataset
+     *
+     * @param base The dataset which has the number of points that should be used as sliding window, all but the
+     *                    oldest point of this will be copied as a basis for the created dataset
+     * @param newCapacity must be reasonable larger then the length of the base dataset (usually 1.5 to 2 times
+     *                    the length)
+     */
+    protected AggregateDataset(AggregateDataset<T> base, int newCapacity) {
+        if (newCapacity <= base.length) {
+            throw new IllegalArgumentException("Capacity must be larger than the sliding window size (length of base dataset)");
+        }
+        this.length = base.length; // length stays the same but we slide a window
+        this.offset = base.length;
+        this.mins = new long[newCapacity];
+        this.maxs = new long[newCapacity];
+        this.avgs = new double[newCapacity];
+        this.points = new int[newCapacity];
+        AggregateDataset<T> src = base;
+        int copyLength = src.length - 1;
+        int copyOffset = src.lastIndex() - copyLength;
+        this.firstTime = base.getTime(copyOffset);
+        arraycopy(src.mins, copyOffset, mins, 0, copyLength);
+        arraycopy(src.maxs, copyOffset, maxs, 0, copyLength);
+        arraycopy(src.avgs, copyOffset, avgs, 0, copyLength);
+        arraycopy(src.points, copyOffset, points, 0, copyLength);
+    }
+
+    /**
+     * Used when adding points to the sliding window.
+     *
+     * @param predecessor Must be an instance created with the copy constructor for new sliding windows
+     */
+    protected AggregateDataset(AggregateDataset<T> predecessor) {
+        this.mins = predecessor.mins;
+        this.maxs = predecessor.maxs;
+        this.avgs = predecessor.avgs;
+        this.points = predecessor.points;
+        this.length = predecessor.length; // length stays the same but we slide a window
+        this.offset = predecessor.offset + 1;
+        this.firstTime = predecessor.getTime(predecessor.firstIndex() + 1);
+    }
+
+    protected final void setEntry(int points, long min, long max, double avg) {
+        int index = lastIndex();
+        this.points[index] = points;
+        this.mins[index] = min;
+        this.maxs[index] = max;
+        this.avgs[index] = avg;
+    }
+
+    /**
+     * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The minimum value of all values recorded in the provided minute
      */
     public long getMinimum(int index) {
@@ -43,7 +111,7 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
     }
 
     /**
-     * @param index 0-59
+     * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The maximum value of all values recorded in the provided minute
      */
     public long getMaximum(int index) {
@@ -51,19 +119,19 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
     }
 
     /**
-     * @param minuteOfHour 0-59
+     * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The average of all values recorded in the provided minute
      */
-    public double getAverage(int minuteOfHour) {
-        return avgs[minuteOfHour];
+    public double getAverage(int index) {
+        return avgs[index];
     }
 
     /**
-     * @param minuteOfHour 0-59
+     * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The number of points recorded in the provided minute that were used to compute min, max and average values.
      */
-    public int getNumberOfPoints(int minuteOfHour) {
-        return points[minuteOfHour];
+    public int getNumberOfPoints(int index) {
+        return points[index];
     }
 
     /**
@@ -74,13 +142,50 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
     }
 
     /**
-     * @return the number of minutes (in an hour) contained in this {@link MinutesDataset}, 0-60
+     * @return the number of data points in this set.
+     *
+     * For example the number of minutes in an hour (0-60)
+     * or the numbers of hours in a day (0-24)
      */
     public int length() {
         return length;
     }
 
+    /**
+     * @return the total number of points that can be stored. This refers to the underlying shared array. Different
+     *         instances of {@link AggregateDataset} instances reference to sections within the same array using
+     *         {@link #offset} and {@link #length()}. While adding points writes to the array only so far unused cells
+     *         are written and referenced. Once written the cell does not change.
+     */
     public int capacity() {
         return points.length;
     }
+
+    /**
+     * @return Is the first index in the underlying array that is used by this dataset.
+     *
+     *         No index smaller than this must be passed to any of the methods accepting an index value.
+     */
+    public int firstIndex() {
+        return offset;
+    }
+
+    /**
+     * @return Is the last index in the underlying array that is used by this dataset.
+     *
+     *         No index larger than this must be passed to any of the methods accepting an index value.
+     */
+    public int lastIndex() {
+        return offset + length;
+    }
+
+    /**
+     * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
+     * @return the timestamp value for the values of the given index.
+     *
+     *         This value is computed based on the {@link #firstTime()}, the {@link #firstIndex()} and the interval
+     *         between data points which depends on the subclass.
+     */
+    public abstract long getTime(int index);
+
 }

--- a/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
@@ -2,81 +2,108 @@ package fish.payara.monitoring.model;
 
 import static java.lang.System.arraycopy;
 
+/**
+ * Base class for specific {@link AggregateDataset}s.
+ *
+ * An {@link AggregateDataset} is statistical data. The original data points are aggregated within intervals to minimum,
+ * maximum and average values as well as remembering the number of points used to compute these aggregates.
+ *
+ * When adding to the dataset new instances are created each time but many will share the same underlying arrays to
+ * store data. Once data is written to an array index that particular element is never changed again. Therefore it can
+ * be shared. When index exceeds the capacity or would override a used index after a wrap the data from the arrays are
+ * copied to a new array of twice the capacity. In this new underlying storage a window of single capacity will slide
+ * until it reached again the end of the double capacity at which point a single capacity is copied again. This then
+ * continues endlessly offering effectively immutable sliding windows of single capacity size.
+ *
+ * @author Jan Bernitt
+ *
+ * @param <T> Type of the extending subclass of this type (self referencing type)
+ *
+ * @see MinutesDataset
+ * @see HoursDataset
+ */
 public abstract class AggregateDataset<T extends AggregateDataset<T>> {
 
     private final long[] mins;
     private final long[] maxs;
     private final double[] avgs;
-    protected final int[] points;
-    protected final long firstTime;
+    private final int[] points;
+    private final long firstTime;
     /**
      * Data on or after the offset index is in the {@link #firstTime} hour when recording started,
      * data before the offset index is in the hour after the one when recording started
      */
     protected final int offset;
-    protected int length;
+    private int size;
 
     /**
      * Used to create a new empty dataset.
-     *
-     * @param capacity the initial capacity that should be equal to the number of points in the interval, for example 60
-     *                 for minutes in an hour
      */
-    protected AggregateDataset(int capacity) {
-        this.mins = new long[capacity];
-        this.maxs = new long[capacity];
-        this.avgs = new double[capacity];
-        this.points = new int[capacity];
+    protected AggregateDataset() {
+        this.mins = new long[0];
+        this.maxs = new long[0];
+        this.avgs = new double[0];
+        this.points = new int[0];
         this.firstTime = -1L;
-        this.offset = 0;
-        this.length = 0;
+        this.offset = -1;
+        this.size = 0;
     }
 
     /**
-     * Used when appending a new point to a dataset of initial capacity.
+     * Used when appending a new point to a dataset of single capacity.
      *
      * @param predecessor The dataset which has 1 datapoint less than this will have
+     * @param capacity    the single capacity (no sliding window) only used in case the predecessor was the empty set
      * @param offset      the offset of this dataset; this is the same as the one of the predecessor (if set) or the one
      *                    of the first datapoint
      * @param firstTime   the first time of this dataset; this is the same as the one of the predecessor (if set) or the
      *                    one of the first datapoint
      */
-    protected AggregateDataset(AggregateDataset<T> predecessor, int offset, long firstTime) {
-        this.mins = predecessor.mins;
-        this.maxs = predecessor.maxs;
-        this.avgs = predecessor.avgs;
-        this.points = predecessor.points;
+    protected AggregateDataset(AggregateDataset<T> predecessor, int capacity, int offset, long firstTime) {
+        boolean first = predecessor.size == 0;
+        this.mins = first ? new long[capacity] : predecessor.mins;
+        this.maxs = first ? new long[capacity] : predecessor.maxs;
+        this.avgs = first ? new double[capacity] : predecessor.avgs;
+        this.points = first ? new int[capacity] : predecessor.points;
         this.offset = offset;
-        this.length = predecessor.length + 1;
+        this.size = predecessor.size + 1;
         this.firstTime = firstTime;
     }
 
     /**
      * Used when copying a section of the base dataset as a basis for a new sliding window dataset
      *
-     * @param base The dataset which has the number of points that should be used as sliding window, all but the
+     * @param predecessor The dataset which has the number of points that should be used as sliding window, all but the
      *                    oldest point of this will be copied as a basis for the created dataset
      * @param newCapacity must be reasonable larger then the length of the base dataset (usually 1.5 to 2 times
      *                    the length)
      */
-    protected AggregateDataset(AggregateDataset<T> base, int newCapacity) {
-        if (newCapacity <= base.length) {
+    protected AggregateDataset(AggregateDataset<T> predecessor, int newCapacity) {
+        if (newCapacity <= predecessor.size) {
             throw new IllegalArgumentException("Capacity must be larger than the sliding window size (length of base dataset)");
         }
-        this.length = base.length; // length stays the same but we slide a window
-        this.offset = base.length;
+        this.size = predecessor.size; // window length stays the same and is the single capacity
+        this.offset = 0; // a copy should always occur when a full interval has been recorded, this is either when single capacity is filled up or when double capacity has slided to the end
         this.mins = new long[newCapacity];
         this.maxs = new long[newCapacity];
         this.avgs = new double[newCapacity];
         this.points = new int[newCapacity];
-        AggregateDataset<T> src = base;
-        int copyLength = src.length - 1;
-        int copyOffset = src.lastIndex() - copyLength;
-        this.firstTime = base.getTime(copyOffset);
-        arraycopy(src.mins, copyOffset, mins, 0, copyLength);
-        arraycopy(src.maxs, copyOffset, maxs, 0, copyLength);
-        arraycopy(src.avgs, copyOffset, avgs, 0, copyLength);
-        arraycopy(src.points, copyOffset, points, 0, copyLength);
+        AggregateDataset<T> src = predecessor;
+        int from = src.firstIndex();
+        int to = Math.max(from + src.size, src.capacity());
+        int copyLength = to - from;
+        this.firstTime = predecessor.getTime(from);
+        arraycopy(src.mins, from, mins, 0, copyLength);
+        arraycopy(src.maxs, from, maxs, 0, copyLength);
+        arraycopy(src.avgs, from, avgs, 0, copyLength);
+        arraycopy(src.points, from, points, 0, copyLength);
+        if (copyLength < src.size) { // there was a wrap that needs copying as well
+            copyLength = src.size - copyLength;
+            arraycopy(src.mins, 0, mins, to, copyLength);
+            arraycopy(src.maxs, 0, maxs, to, copyLength);
+            arraycopy(src.avgs, 0, avgs, to, copyLength);
+            arraycopy(src.points,0, points, to, copyLength);
+        }
     }
 
     /**
@@ -89,7 +116,7 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
         this.maxs = predecessor.maxs;
         this.avgs = predecessor.avgs;
         this.points = predecessor.points;
-        this.length = predecessor.length; // length stays the same but we slide a window
+        this.size = predecessor.size; // length stays the same but we slide a window
         this.offset = predecessor.offset + 1;
         this.firstTime = predecessor.getTime(predecessor.firstIndex() + 1);
     }
@@ -106,7 +133,7 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
      * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The minimum value of all values recorded in the provided minute
      */
-    public long getMinimum(int index) {
+    public final long getMinimum(int index) {
         return mins[index];
     }
 
@@ -114,7 +141,7 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
      * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The maximum value of all values recorded in the provided minute
      */
-    public long getMaximum(int index) {
+    public final long getMaximum(int index) {
         return maxs[index];
     }
 
@@ -122,7 +149,7 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
      * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The average of all values recorded in the provided minute
      */
-    public double getAverage(int index) {
+    public final double getAverage(int index) {
         return avgs[index];
     }
 
@@ -130,14 +157,14 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
      * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
      * @return The number of points recorded in the provided minute that were used to compute min, max and average values.
      */
-    public int getNumberOfPoints(int index) {
+    public final int getNumberOfPoints(int index) {
         return points[index];
     }
 
     /**
      * @return The start of the minute when this {@link MinutesDataset} started to be filled with data
      */
-    public long firstTime() {
+    public final long firstTime() {
         return firstTime;
     }
 
@@ -147,45 +174,68 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
      * For example the number of minutes in an hour (0-60)
      * or the numbers of hours in a day (0-24)
      */
-    public int length() {
-        return length;
+    public final int size() {
+        return size;
     }
 
     /**
      * @return the total number of points that can be stored. This refers to the underlying shared array. Different
      *         instances of {@link AggregateDataset} instances reference to sections within the same array using
-     *         {@link #offset} and {@link #length()}. While adding points writes to the array only so far unused cells
+     *         {@link #offset} and {@link #size()}. While adding points writes to the array only so far unused cells
      *         are written and referenced. Once written the cell does not change.
      */
-    public int capacity() {
+    public final int capacity() {
         return points.length;
     }
 
     /**
-     * @return Is the first index in the underlying array that is used by this dataset.
+     * @return Is the chronologically first index in the underlying array that is used by this dataset.
      *
      *         No index smaller than this must be passed to any of the methods accepting an index value.
+     *
+     *         An empty set returns -1
      */
-    public int firstIndex() {
+    public final int firstIndex() {
         return offset;
     }
 
     /**
-     * @return Is the last index in the underlying array that is used by this dataset.
+     * @return Is the chronologically last index in the underlying array that is used by this dataset.
      *
      *         No index larger than this must be passed to any of the methods accepting an index value.
+     *
+     *         Note that this can "wrap" and return a lower index than {@link #firstIndex()} which means the array
+     *         elements from 0 to the last index are chronologically after the element at the array which start
+     *         chronologically at the {@link #firstIndex()}.
+     *
+     *         An empty set returns -1
      */
-    public int lastIndex() {
-        return offset + length;
+    public final int lastIndex() {
+        return size == 0 ? -1 : (offset + size - 1) % capacity();
+    }
+
+    /**
+     * @return true if the set has wrapped, that means at least one element chronologically following the item at the
+     *         end of the array is stored between index zero and {@link #offset}.
+     */
+    public final boolean isWrapped() {
+        return offset + size >= capacity();
     }
 
     /**
      * @param index a value between {@link #firstIndex()} and {@link #lastIndex()} (inclusive)
-     * @return the timestamp value for the values of the given index.
+     * @return the timestamp value pointing to the beginning of the aggregated interval at the given index, for example
+     *         for a minute aggregate this points to to the second at the start of the minute.
      *
      *         This value is computed based on the {@link #firstTime()}, the {@link #firstIndex()} and the interval
      *         between data points which depends on the subclass.
      */
     public abstract long getTime(int index);
+
+    /**
+     * @return The duration of the time-span that got aggregated into one data point (index). This is the same for any
+     *         of the indexes as the interval aggregated is constant/regular.
+     */
+    public abstract long getIntervalLength();
 
 }

--- a/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
@@ -1,0 +1,86 @@
+package fish.payara.monitoring.model;
+
+public abstract class AggregateDataset<T extends AggregateDataset<T>> {
+
+    protected final long[] mins;
+    protected final long[] maxs;
+    protected final double[] avgs;
+    protected final int[] points;
+    protected final long firstTime;
+    /**
+     * Data on or after the offset index is in the {@link #firstTime} hour when recording started,
+     * data before the offset index is in the hour after the one when recording started
+     */
+    protected final int offset;
+    protected int length;
+
+    public  AggregateDataset(int maxLength) {
+        this.mins = new long[maxLength];
+        this.maxs = new long[maxLength];
+        this.avgs = new double[maxLength];
+        this.points = new int[maxLength];
+        this.firstTime = -1L;
+        this.offset = 0;
+        this.length = 0;
+    }
+
+    public AggregateDataset(AggregateDataset<T> predecessor, int offset, long firstTime) {
+        this.mins = predecessor.mins;
+        this.maxs = predecessor.maxs;
+        this.avgs = predecessor.avgs;
+        this.points = predecessor.points;
+        this.offset = offset;
+        this.length = predecessor.length + 1;
+        this.firstTime = firstTime;
+    }
+
+    /**
+     * @param index 0-59
+     * @return The minimum value of all values recorded in the provided minute
+     */
+    public long getMinimum(int index) {
+        return mins[index];
+    }
+
+    /**
+     * @param index 0-59
+     * @return The maximum value of all values recorded in the provided minute
+     */
+    public long getMaximum(int index) {
+        return maxs[index];
+    }
+
+    /**
+     * @param minuteOfHour 0-59
+     * @return The average of all values recorded in the provided minute
+     */
+    public double getAverage(int minuteOfHour) {
+        return avgs[minuteOfHour];
+    }
+
+    /**
+     * @param minuteOfHour 0-59
+     * @return The number of points recorded in the provided minute that were used to compute min, max and average values.
+     */
+    public int getNumberOfPoints(int minuteOfHour) {
+        return points[minuteOfHour];
+    }
+
+    /**
+     * @return The start of the minute when this {@link MinutesDataset} started to be filled with data
+     */
+    public long firstTime() {
+        return firstTime;
+    }
+
+    /**
+     * @return the number of minutes (in an hour) contained in this {@link MinutesDataset}, 0-60
+     */
+    public int length() {
+        return length;
+    }
+
+    public int capacity() {
+        return points.length;
+    }
+}

--- a/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/AggregateDataset.java
@@ -168,6 +168,10 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
         return firstTime;
     }
 
+    public final boolean isEmpty() {
+        return size == 0;
+    }
+
     /**
      * @return the number of data points in this set.
      *
@@ -237,5 +241,45 @@ public abstract class AggregateDataset<T extends AggregateDataset<T>> {
      *         of the indexes as the interval aggregated is constant/regular.
      */
     public abstract long getIntervalLength();
+
+    /**
+     * @return minimum values in chronological order
+     */
+    public long[] mins() {
+        return copy(mins, new long[size]);
+    }
+
+    /**
+     * @return maximum values in chronological order
+     */
+    public long[] maxs() {
+        return copy(maxs, new long[size]);
+    }
+
+    /**
+     * @return average values in chronological order
+     */
+    public double[] avgs() {
+        return copy(avgs, new double[size]);
+    }
+
+    /**
+     * @return number of points aggregated into min/max/avg in chronological order
+     */
+    public int[] numberOfPoints() {
+        return copy(points, new int[size]);
+    }
+
+    private <A> A copy(A src, A dest) {
+        int from = firstIndex();
+        if (!isWrapped()) {
+            arraycopy(src, from, dest, 0, size);
+            return dest;
+        }
+        int len = capacity() - from;
+        arraycopy(src, from, dest, 0, len);
+        arraycopy(src, 0, dest, len, size - len);
+        return dest;
+    }
 
 }

--- a/process/src/main/java/fish/payara/monitoring/model/ConstantDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/ConstantDataset.java
@@ -179,6 +179,6 @@ public class ConstantDataset extends SeriesDataset {
 
     @Override
     public int estimatedBytesMemory() {
-        return 56;
+        return 64 + recentMinute.estimatedBytesMemory();
     }
 }

--- a/process/src/main/java/fish/payara/monitoring/model/DaysDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/DaysDataset.java
@@ -1,0 +1,87 @@
+package fish.payara.monitoring.model;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAdjusters;
+
+public final class DaysDataset extends AggregateDataset<DaysDataset> {
+
+    private static final int SINGLE_CAPACITY = 31;
+    private static final int DOUBLE_CAPACITY = 2 * SINGLE_CAPACITY;
+
+    private static final long MILLIS_IN_ONE_DAY = Duration.ofDays(1).toMillis();
+
+    public static final DaysDataset EMPTY = new DaysDataset();
+
+    private DaysDataset() {
+        super();
+    }
+
+    private DaysDataset(DaysDataset predecessor, HoursDataset day) {
+        super(predecessor, SINGLE_CAPACITY, offset(predecessor, day), firstTime(predecessor, day));
+        aggregate(day);
+    }
+
+    private DaysDataset(DaysDataset predecessor, HoursDataset day, int newCapacity) {
+        super(predecessor, newCapacity);
+        aggregate(day);
+    }
+
+    private DaysDataset(HoursDataset day, DaysDataset predecessor) {
+        super(predecessor);
+        aggregate(day);
+    }
+
+    private static long firstTime(DaysDataset predecessor, HoursDataset day) {
+        return predecessor.size() > 0
+                ? predecessor.firstTime()
+                : atStartOfDay(day).withMinute(0).withSecond(0).withNano(0).toInstant().toEpochMilli();
+    }
+
+    private static int offset(DaysDataset predecessor, HoursDataset day) {
+        return predecessor.size() > 0
+                ? predecessor.offset
+                : dayOfMonth(day);
+    }
+
+    private static int dayOfMonth(HoursDataset day) {
+        return atStartOfDay(day).getDayOfMonth();
+    }
+
+    private static OffsetDateTime atStartOfDay(HoursDataset day) {
+        return Instant.ofEpochMilli(day.firstTime()).atOffset(ZoneOffset.UTC);
+    }
+
+    private void aggregate(HoursDataset day) {
+
+    }
+
+    /**
+     * @return true if this dataset contains data up to and including the last day of the month, else false.
+     *
+     *         Note that this day various with the length of the month.
+     */
+    public boolean isEndOfMonth() {
+        if (size() == 0) {
+            return false;
+        }
+        OffsetDateTime time = Instant.ofEpochMilli(getTime(lastIndex())).atOffset(ZoneOffset.UTC);
+        return time.getDayOfMonth() == time.with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth();
+    }
+
+    @Override
+    public long getTime(int dayOfMonth) {
+        int daysIn = dayOfMonth - offset;
+        if (daysIn < 0) { // wrap
+            daysIn = (capacity() - offset);
+        }
+        return firstTime() + (daysIn * MILLIS_IN_ONE_DAY);
+    }
+
+    @Override
+    public long getIntervalLength() {
+        return MILLIS_IN_ONE_DAY;
+    }
+}

--- a/process/src/main/java/fish/payara/monitoring/model/DaysDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/DaysDataset.java
@@ -1,5 +1,7 @@
 package fish.payara.monitoring.model;
 
+import static java.time.ZoneOffset.UTC;
+
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
@@ -9,9 +11,7 @@ import java.time.temporal.TemporalAdjusters;
 
 public final class DaysDataset extends AggregateDataset<DaysDataset> {
 
-    private static final int SINGLE_CAPACITY = 31;
-    private static final int DOUBLE_CAPACITY = 2 * SINGLE_CAPACITY;
-
+    private static final int DAYS_PER_MONTH = 31;
     private static final long MILLIS_IN_ONE_DAY = Duration.ofDays(1).toMillis();
 
     public static final DaysDataset EMPTY = new DaysDataset();
@@ -21,61 +21,30 @@ public final class DaysDataset extends AggregateDataset<DaysDataset> {
     }
 
     private DaysDataset(DaysDataset predecessor, HoursDataset day) {
-        super(predecessor, SINGLE_CAPACITY, offset(predecessor, day), firstTime(predecessor, day));
+        super(DAYS_PER_MONTH, predecessor, atStartOfDay(day.lastTime()));
         aggregate(day);
     }
 
-    private DaysDataset(DaysDataset predecessor, HoursDataset day, int newCapacity) {
-        super(predecessor, newCapacity);
-        aggregate(day);
-    }
-
-    private DaysDataset(HoursDataset day, DaysDataset predecessor) {
-        super(predecessor);
-        aggregate(day);
-    }
-
-    private static long firstTime(DaysDataset predecessor, HoursDataset day) {
-        return !predecessor.isEmpty()
-                ? predecessor.firstTime()
-                : atStartOfDay(day).withMinute(0).withSecond(0).withNano(0).toInstant().toEpochMilli();
-    }
-
-    private static int offset(DaysDataset predecessor, HoursDataset day) {
-        return !predecessor.isEmpty()
-                ? predecessor.offset
-                : dayOfMonth(day);
-    }
-
-    private static int dayOfMonth(HoursDataset day) {
-        return atStartOfDay(day).getDayOfMonth();
-    }
-
-    private static OffsetDateTime atStartOfDay(HoursDataset day) {
-        return Instant.ofEpochMilli(day.firstTime()).atOffset(ZoneOffset.UTC);
+    public static long atStartOfDay(long time) {
+        return Instant.ofEpochMilli(time).atOffset(UTC)
+                .withNano(0)
+                .withSecond(0)
+                .withMinute(0)
+                .withHour(0)
+                .toInstant().toEpochMilli();
     }
 
     public DaysDataset add(HoursDataset day) {
-        if (!day.isEndOfDay()) {
+        if (!day.endsWithLastHourOfDay()) {
             return this;
         }
-        if (capacity() == 0) {
-            return new DaysDataset(this, day);
-        }
-        if (capacity() == SINGLE_CAPACITY) {
-            return size() == SINGLE_CAPACITY
-                    ? new DaysDataset(this, day, DOUBLE_CAPACITY)
-                    : new DaysDataset(this, day);
-        }
-        return isEndOfMonth()
-                ? new DaysDataset(this, day, DOUBLE_CAPACITY)
-                : new DaysDataset(day, this);
+        return new DaysDataset(this, day);
     }
 
     private void aggregate(HoursDataset day) {
         int numberOfHoursInAggregate = day.size();
         int firstHourOfDay = day.offset;
-        int lastHourOfDay = Math.max(23, firstHourOfDay + numberOfHoursInAggregate);
+        int lastHourOfDay = Math.min(23, firstHourOfDay + numberOfHoursInAggregate);
         int points = day.getNumberOfPoints(firstHourOfDay);
         long min = day.getMinimum(firstHourOfDay);
         long max = day.getMaximum(firstHourOfDay);
@@ -87,7 +56,7 @@ public final class DaysDataset extends AggregateDataset<DaysDataset> {
             avg = avg.add(BigDecimal.valueOf(day.getAverage(i)));
         }
         setEntry(points, min, max,
-                avg.divide(BigDecimal.valueOf(numberOfHoursInAggregate)).doubleValue());
+                avg.divide(BigDecimal.valueOf(numberOfHoursInAggregate), BigDecimal.ROUND_DOWN).doubleValue());
     }
 
     /**
@@ -95,21 +64,12 @@ public final class DaysDataset extends AggregateDataset<DaysDataset> {
      *
      *         Note that this day various with the length of the month.
      */
-    public boolean isEndOfMonth() {
-        if (size() == 0) {
+    public boolean endsWithLastDayOfMonth() {
+        if (isEmpty()) {
             return false;
         }
         OffsetDateTime time = Instant.ofEpochMilli(getTime(lastIndex())).atOffset(ZoneOffset.UTC);
         return time.getDayOfMonth() == time.with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth();
-    }
-
-    @Override
-    public long getTime(int dayOfMonth) {
-        int daysIn = dayOfMonth - offset;
-        if (daysIn < 0) { // wrap
-            daysIn = (capacity() - offset);
-        }
-        return firstTime() + (daysIn * MILLIS_IN_ONE_DAY);
     }
 
     @Override

--- a/process/src/main/java/fish/payara/monitoring/model/EmptyDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/EmptyDataset.java
@@ -46,7 +46,7 @@ import java.math.BigInteger;
  * The {@link EmptyDataset} is the starting point for any of the other {@link SeriesDataset} implementations.
  *
  * When first point is added to the {@link EmptyDataset} it becomes a {@link ConstantDataset}.
- * 
+ *
  * {@link EmptyDataset} are initialised with a {@link #capacity} so it can be passed on as the set eventually evolves
  * into a {@link PartialDataset} which has a {@link #capacity()} limit.
  *
@@ -72,8 +72,13 @@ public final class EmptyDataset extends SeriesDataset {
     }
 
     @Override
-    public SeriesDataset add(long time, long value) {
-        return new ConstantDataset(this, time, value);
+    public SeriesDataset add(long time, long value, boolean aggregate) {
+        return new ConstantDataset(this, time, value, aggregate);
+    }
+
+    @Override
+    public MinutesDataset getRecentMinutes() {
+        return MinutesDataset.EMPTY;
     }
 
     @Override

--- a/process/src/main/java/fish/payara/monitoring/model/HoursDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/HoursDataset.java
@@ -1,0 +1,24 @@
+package fish.payara.monitoring.model;
+
+public final class HoursDataset extends AggregateDataset<HoursDataset> {
+
+    public HoursDataset() {
+        super(24);
+    }
+
+    public HoursDataset(HoursDataset predecessor, MinutesDataset hour) {
+        super(predecessor, 0, 0);
+    }
+
+    private static int offset(HoursDataset predecessor, MinutesDataset hour) {
+        return predecessor.length > 0
+            ? predecessor.offset
+            : minuteOfHour(minute);
+    }
+
+    private static long firstTime(HoursDataset predecessor, MinutesDataset hour) {
+        return predecessor.length > 0
+                ? predecessor.firstTime
+                : lastDateTime(minute).withSecond(0).withNano(0).toInstant().toEpochMilli();
+    }
+}

--- a/process/src/main/java/fish/payara/monitoring/model/HoursDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/HoursDataset.java
@@ -1,24 +1,95 @@
 package fish.payara.monitoring.model;
 
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * A {@link HoursDataset} contains up to 24 hours of statistical data with one data point per hour for minimum, maximum,
+ * average and the number of points these originate from.
+ *
+ * @author Jan Bernitt
+ */
 public final class HoursDataset extends AggregateDataset<HoursDataset> {
 
+    private static final long MILLIS_IN_ONE_HOUR = Duration.ofHours(1).toMillis();
+
+    /**
+     * Creates an empty {@link HoursDataset}.
+     */
     public HoursDataset() {
         super(24);
     }
 
-    public HoursDataset(HoursDataset predecessor, MinutesDataset hour) {
-        super(predecessor, 0, 0);
+    private HoursDataset(HoursDataset predecessor, MinutesDataset hour) {
+        super(predecessor, offset(predecessor, hour), firstTime(predecessor, hour));
+        if (lastIndex() != hourOfDay(hour)) {
+            throw new IllegalArgumentException("Hour did not directly follow the end of the predecessor");
+        }
+        aggregate(hour);
     }
 
     private static int offset(HoursDataset predecessor, MinutesDataset hour) {
         return predecessor.length > 0
             ? predecessor.offset
-            : minuteOfHour(minute);
+            : hourOfDay(hour);
     }
 
     private static long firstTime(HoursDataset predecessor, MinutesDataset hour) {
         return predecessor.length > 0
                 ? predecessor.firstTime
-                : lastDateTime(minute).withSecond(0).withNano(0).toInstant().toEpochMilli();
+                : lastDateTime(hour).withMinute(0).withSecond(0).withNano(0).toInstant().toEpochMilli();
+    }
+
+    private static int hourOfDay(MinutesDataset hour) {
+        return lastDateTime(hour).getHour();
+    }
+
+    private static OffsetDateTime lastDateTime(MinutesDataset hour) {
+        return Instant.ofEpochMilli(hour.firstTime()).atOffset(ZoneOffset.UTC);
+    }
+
+    public HoursDataset add(MinutesDataset hour) {
+        if (!hour.isEndOfHour()) {
+            throw new IllegalArgumentException("Only add complete hour to an HoursDataset");
+        }
+        //TODO
+        return new HoursDataset(this, hour);
+    }
+
+    private void aggregate(MinutesDataset hour) {
+        int numberOfMinutesInAggregate = hour.length; // might be less then 60 when first starting to record in the middle of an hour
+        int firstMinuteOfHour = hour.offset;
+        int lastMiniteOfHour = Math.max(59, firstMinuteOfHour + numberOfMinutesInAggregate);
+        int points = hour.getNumberOfPoints(firstMinuteOfHour);
+        long min = hour.getMaximum(firstMinuteOfHour);
+        long max = hour.getMaximum(firstMinuteOfHour);
+        BigDecimal avg = BigDecimal.valueOf(hour.getAverage(firstMinuteOfHour));
+        for (int i = firstMinuteOfHour + 1; i <= lastMiniteOfHour; i++) {
+            points += hour.getNumberOfPoints(i);
+            min = Math.min(min, hour.getMinimum(i));
+            max = Math.max(max, hour.getMaximum(i));
+            avg = avg.add(BigDecimal.valueOf(hour.getAverage(i)));
+        }
+        setEntry(points, min, max,
+                avg.divide(BigDecimal.valueOf(numberOfMinutesInAggregate)).doubleValue());
+    }
+
+    /**
+     * @return true if this dataset contains data up to and including the last hour of the day, else false
+     */
+    public boolean isEndOfDay() {
+        return lastIndex() == 23;
+    }
+
+    @Override
+    public long getTime(int hourOfDay) {
+        int hoursIn = hourOfDay - offset;
+        if (hoursIn < 0) { // next day
+            hoursIn = (capacity() - offset) + hourOfDay;
+        }
+        return firstTime + (hoursIn * MILLIS_IN_ONE_HOUR);
     }
 }

--- a/process/src/main/java/fish/payara/monitoring/model/MinutesDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/MinutesDataset.java
@@ -1,0 +1,71 @@
+package fish.payara.monitoring.model;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * A {@link MinutesDataset} contains up to 60 minutes of statistical data with one data point per minute for minimum,
+ * maximum, average and number of points that original {@link SeriesDataset} had for that minute.
+ *
+ * @author Jan Bernitt
+ */
+public final class MinutesDataset extends AggregateDataset<MinutesDataset> {
+
+    public MinutesDataset() {
+        super(60);
+    }
+
+    public MinutesDataset(MinutesDataset predecessor, SeriesDataset minute) {
+        super(predecessor, offset(predecessor, minute), firstTime(predecessor, minute));
+        aggregate(minute, minuteOfHour(minute));
+    }
+
+    private static int offset(MinutesDataset predecessor, SeriesDataset minute) {
+        return predecessor.length > 0
+            ? predecessor.offset
+            : minuteOfHour(minute);
+    }
+
+    private static long firstTime(MinutesDataset predecessor, SeriesDataset minute) {
+        return predecessor.length > 0
+                ? predecessor.firstTime
+                : lastDateTime(minute).withSecond(0).withNano(0).toInstant().toEpochMilli();
+    }
+
+    private static int minuteOfHour(SeriesDataset minute) {
+        return lastDateTime(minute).getMinute();
+    }
+
+    private static OffsetDateTime lastDateTime(SeriesDataset minute) {
+        return Instant.ofEpochMilli(minute.lastTime()).atOffset(ZoneOffset.UTC);
+    }
+
+    private void aggregate(SeriesDataset minute, int minuteOfHour) {
+        long[] points = minute.points();
+        this.points[minuteOfHour] = points.length / 2;
+        long min = points[1];
+        long max = points[1];
+        BigInteger avg = BigInteger.valueOf(points[1]);
+        for (int i = 3; i < points.length; i+=2) {
+            long val = points[i];
+            min = Math.min(min, val);
+            max = Math.max(max, val);
+            avg = avg.add(BigInteger.valueOf(val));
+        }
+        this.mins[minuteOfHour] = min;
+        this.maxs[minuteOfHour] = max;
+        this.avgs[minuteOfHour] = new BigDecimal(avg).divide(BigDecimal.valueOf(this.points[minuteOfHour])).doubleValue();
+    }
+
+    public long getTime(int minuteOfHour) {
+        int minutesIn = minuteOfHour - offset;
+        if (minutesIn < 0) { // next hour
+            minutesIn = (capacity() - offset) + minuteOfHour;
+        }
+        return firstTime + (minutesIn * 60000L);
+    }
+
+}

--- a/process/src/main/java/fish/payara/monitoring/model/MinutesDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/MinutesDataset.java
@@ -1,11 +1,11 @@
 package fish.payara.monitoring.model;
 
+import static java.time.ZoneOffset.UTC;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 
 /**
  * A {@link MinutesDataset} contains up to 60 minutes of statistical data with one data point per minute for minimum,
@@ -21,9 +21,7 @@ import java.time.ZoneOffset;
  */
 public final class MinutesDataset extends AggregateDataset<MinutesDataset> {
 
-    private static final int SINGLE_CAPACITY = 60;
-    private static final int DOUBLE_CAPACITY = 2 * SINGLE_CAPACITY;
-
+    private static final int MINUTES_PER_HOUR = 60;
     private static final long MILLIS_IN_ONE_MINUTE = Duration.ofMinutes(1).toMillis();
 
     public static final MinutesDataset EMPTY = new MinutesDataset();
@@ -36,44 +34,16 @@ public final class MinutesDataset extends AggregateDataset<MinutesDataset> {
     }
 
     private MinutesDataset(MinutesDataset predecessor, SeriesDataset minute) {
-        super(predecessor, SINGLE_CAPACITY, offset(predecessor, minute), firstTime(predecessor, minute));
-        if (lastIndex() != minuteOfHour(minute)) {
-            throw new IllegalArgumentException("Minute did not directly continue the end of the predecessor");
-        }
+        super(MINUTES_PER_HOUR, predecessor, atStartOfMinute(minute.lastTime()));
         aggregate(minute);
         this.recentHours = predecessor.recentHours.add(this);
     }
 
-    private MinutesDataset(MinutesDataset predecessor, SeriesDataset minute, int newCapacity) {
-        super(predecessor, newCapacity);
-        aggregate(minute);
-        this.recentHours = predecessor.recentHours.add(this);
-    }
-
-    private MinutesDataset(SeriesDataset minute, MinutesDataset predecessor) {
-        super(predecessor);
-        aggregate(minute);
-        this.recentHours = predecessor.recentHours.add(this);
-    }
-
-    private static int offset(MinutesDataset predecessor, SeriesDataset minute) {
-        return !predecessor.isEmpty()
-            ? predecessor.offset
-            : minuteOfHour(minute);
-    }
-
-    private static long firstTime(MinutesDataset predecessor, SeriesDataset minute) {
-        return !predecessor.isEmpty()
-            ? predecessor.firstTime()
-            : atEndOfMinute(minute).withSecond(0).withNano(0).toInstant().toEpochMilli();
-    }
-
-    private static int minuteOfHour(SeriesDataset minute) {
-        return atEndOfMinute(minute).getMinute();
-    }
-
-    private static OffsetDateTime atEndOfMinute(SeriesDataset minute) {
-        return Instant.ofEpochMilli(minute.lastTime()).atOffset(ZoneOffset.UTC);
+    private static long atStartOfMinute(long time) {
+        return Instant.ofEpochMilli(time).atOffset(UTC)
+                .withNano(0)
+                .withSecond(0)
+                .toInstant().toEpochMilli();
     }
 
     /**
@@ -86,21 +56,10 @@ public final class MinutesDataset extends AggregateDataset<MinutesDataset> {
     }
 
     public MinutesDataset add(SeriesDataset minute) {
-        if (!minute.isEndOfMinute()) {
+        if (!minute.endsWithLastSecondOfMinute()) {
             return this;
         }
-        if (capacity() == 0) {
-            return new MinutesDataset(this, minute);
-        }
-        if (capacity() == SINGLE_CAPACITY) { // offset => end, start => offset
-            return size() == SINGLE_CAPACITY
-                ? new MinutesDataset(this, minute, DOUBLE_CAPACITY) // complete, start sliding
-                : new MinutesDataset(this, minute); // add (with wrap)
-        }
-        // double capacity
-        return isEndOfHour()
-                ? new MinutesDataset(this, minute, DOUBLE_CAPACITY)
-                : new MinutesDataset(minute, this);
+        return new MinutesDataset(this, minute);
     }
 
     private void aggregate(SeriesDataset minute) {
@@ -116,23 +75,16 @@ public final class MinutesDataset extends AggregateDataset<MinutesDataset> {
             avg = avg.add(BigInteger.valueOf(val));
         }
         setEntry(numberOfPointsInAggregate, min, max,
-                new BigDecimal(avg).divide(BigDecimal.valueOf(numberOfPointsInAggregate)).doubleValue());
+                new BigDecimal(avg).divide(BigDecimal.valueOf(numberOfPointsInAggregate), BigDecimal.ROUND_DOWN).doubleValue());
     }
 
     /**
      * @return true if this dataset contains data up to and including the last minute of the hour, else false
      */
-    public boolean isEndOfHour() {
-        return lastIndex() == SINGLE_CAPACITY - 1;
-    }
-
-    @Override
-    public long getTime(int minuteOfHour) {
-        int minutesIn = minuteOfHour - offset;
-        if (minutesIn < 0) { // next hour
-            minutesIn = (capacity() - offset) + minuteOfHour;
-        }
-        return firstTime() + (minutesIn * MILLIS_IN_ONE_MINUTE);
+    public boolean endsWithLastMinuteOfHour() {
+        return isEmpty()
+                ? false
+                : Instant.ofEpochMilli(lastTime()).atOffset(UTC).getMinute() == 59;
     }
 
     @Override

--- a/process/src/main/java/fish/payara/monitoring/model/PartialDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/PartialDataset.java
@@ -252,7 +252,7 @@ public final class PartialDataset extends SeriesDataset {
 
     @Override
     public int estimatedBytesMemory() {
-        return 108 + (data.length * 8);
+        return 116 + (data.length * 8) + recentMinutes.estimatedBytesMemory();
     }
 
     @Override

--- a/process/src/main/java/fish/payara/monitoring/model/SeriesDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/SeriesDataset.java
@@ -45,9 +45,9 @@ import java.math.BigInteger;
 
 /**
  * A {@link SeriesDataset} contains data observed so far for a particular {@link Series}.
- * 
+ *
  * @author Jan Bernitt
- * 
+ *
  * @see EmptyDataset
  * @see ConstantDataset
  * @see StableDataset
@@ -102,20 +102,20 @@ public abstract class SeriesDataset implements Serializable {
 
     /**
      * Note that minimum is 1 (changing from unknown to know value). Zero means no values have been observed yet.
-     * 
+     *
      * Note also that change count of 1 does not imply
      * that the value never did change just that such a change was never observed.
-     * 
+     *
      * @return Number of times the value as altered since it has been monitored.
      */
     public abstract int getObservedValueChanges();
 
     /**
-     * Example: 
+     * Example:
      * <pre>
      * [t0, v0, t1, v1, t2, v2]
      * </pre>
-     * 
+     *
      * @return this dataset as flat array with alternating time and value data.
      */
     public abstract long[] points();
@@ -173,7 +173,7 @@ public abstract class SeriesDataset implements Serializable {
      * @return the time value of the last of the {@link #points()}
      */
     public abstract long lastTime();
-    
+
     /**
      * @return the maximum number of points in a dataset before adding a new point does remove the oldest point
      */
@@ -192,6 +192,14 @@ public abstract class SeriesDataset implements Serializable {
 
     public final boolean isStableZero() {
         return isStable() && lastValue() == 0L;
+    }
+
+    /**
+     * @return true when this dataset ends with the last second of a minute, else false
+     */
+    public final boolean isEndOfMinute() {
+        long rest = lastTime() % 60000L;
+        return rest >= 59000L && rest < 60000L;
     }
 
     @Override
@@ -228,7 +236,7 @@ public abstract class SeriesDataset implements Serializable {
      * Converts an array of {@link SeriesDataset#points()} to one reflecting the change per second. For each pair of
      * points this is the delta between the earlier and later point of the pair. Since this is a delta the result array
      * contains one less point.
-     * 
+     *
      * @param points point data as returned by {@link SeriesDataset#points()}
      * @return Points representing the delta or per-second change of the provided input data. The delta is associated
      *         with the end point time of each pair.

--- a/process/src/main/java/fish/payara/monitoring/model/SeriesDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/SeriesDataset.java
@@ -55,6 +55,10 @@ import java.math.BigInteger;
  */
 public abstract class SeriesDataset implements Serializable {
 
+    static MinutesDataset aggregate(SeriesDataset predecessor, SeriesDataset successor, boolean aggregate) {
+        return aggregate ? predecessor.getRecentMinutes().add(successor) : MinutesDataset.EMPTY;
+    }
+
     private final Series series;
     private final String instance;
     private final long observedSince;
@@ -120,7 +124,13 @@ public abstract class SeriesDataset implements Serializable {
      */
     public abstract long[] points();
 
-    public abstract SeriesDataset add(long time, long value);
+    public final SeriesDataset add(long time, long value) {
+        return add(time, value, false);
+    }
+
+    public abstract SeriesDataset add(long time, long value, boolean aggregate);
+
+    public abstract MinutesDataset getRecentMinutes();
 
     /**
      * @return The smallest value observed so far. If no value was observed {@link Long#MAX_VALUE}.

--- a/process/src/main/java/fish/payara/monitoring/model/StableDataset.java
+++ b/process/src/main/java/fish/payara/monitoring/model/StableDataset.java
@@ -45,11 +45,11 @@ import java.math.BigInteger;
 /**
  * A {@link StableDataset} is a dataset of a {@link Series} that was a {@link PartialDataset} before it became stable
  * for such a long duration that it moved to a {@link StableDataset}.
- * 
+ *
  * In contrast to a {@link ConstantDataset} a {@link StableDataset} does have a history of observed values changes and
  * differing sum, minimum and maximum values. A {@link ConstantDataset} on the other hand has only ever observed the
  * very same value which is its minimum, maximum and average value for any number of observed values.
- * 
+ *
  * @author Jan Bernitt
  */
 public final class StableDataset extends ConstantDataset {
@@ -60,8 +60,8 @@ public final class StableDataset extends ConstantDataset {
     private final BigInteger observedSum;
     private final int stableCount;
 
-    public StableDataset(SeriesDataset predecessor, long time) {
-        super(predecessor, time);
+    public StableDataset(SeriesDataset predecessor, long time, boolean aggregate) {
+        super(predecessor, time, aggregate);
         this.observedValueChanges = predecessor.getObservedValueChanges();
         this.observedMax = predecessor.getObservedMax();
         this.observedMin = predecessor.getObservedMin();
@@ -95,11 +95,13 @@ public final class StableDataset extends ConstantDataset {
     }
 
     @Override
-    public SeriesDataset add(long time, long value) {
+    public SeriesDataset add(long time, long value, boolean aggregate) {
         if (time == lastTime()) {
-            return new PartialDataset(this, time, value + lastValue());
+            return new PartialDataset(this, time, value + lastValue(), aggregate);
         }
-        return value == lastValue() ? new StableDataset(this, time) : new PartialDataset(this, time, value);
+        return value == lastValue()
+                ? new StableDataset(this, time, aggregate)
+                : new PartialDataset(this, time, value, aggregate);
     }
 
     @Override

--- a/process/src/test/java/fish/payara/monitoring/model/MinutesDatasetTest.java
+++ b/process/src/test/java/fish/payara/monitoring/model/MinutesDatasetTest.java
@@ -2,38 +2,70 @@ package fish.payara.monitoring.model;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.Duration;
+
 import org.junit.Test;
 
 public class MinutesDatasetTest {
 
+    private static final Duration OFFSET_FROM_ABSOLUTE_ZERO = Duration.ofMinutes(30);
+
     @Test
-    public void emptyMinutesAddOne() {
-        MinutesDataset min1 = MinutesDataset.EMPTY.add(minuteAfter(emptySeconds(60), 10));
+    public void oneMinuteAggregate() {
+        SeriesDataset set = createDatasetWithSeconds(60, 10);
+        assertEquals(60, set.size());
+        MinutesDataset min1 = set.getRecentMinutes();
         assertEquals(1, min1.size());
         assertEquals(min1.firstIndex(), min1.lastIndex());
-        assertEquals(1, min1.firstIndex());
-        assertEquals(1, min1.lastIndex());
-        assertEquals(10, min1.getMinimum(min1.firstIndex()));
-        assertEquals(600, min1.getMaximum(min1.firstIndex()));
-        assertEquals(305d, min1.getAverage(min1.firstIndex()), 0.1d);
+        assertEquals(0, min1.firstIndex());
+        assertEquals(0, min1.lastIndex());
+        assertEquals(0, min1.getMinimum(min1.firstIndex()));
+        assertEquals(590, min1.getMaximum(min1.firstIndex()));
+        assertEquals(295d, min1.getAverage(min1.firstIndex()), 0.1d);
         assertEquals(60, min1.getNumberOfPoints(min1.firstIndex()));
-        assertEquals(60000L, min1.getTime(min1.firstIndex()));
+        assertEquals(OFFSET_FROM_ABSOLUTE_ZERO.toMillis(), min1.getTime(min1.firstIndex()));
+    }
+
+    @Test
+    public void twoMinutesAggregate() {
+        SeriesDataset set = createDatasetWithSeconds(120, 10);
+        assertEquals(60, set.size());
+        MinutesDataset min1 = set.getRecentMinutes();
+        assertEquals(2, min1.size());
+        assertEquals(0, min1.firstIndex());
+        assertEquals(1, min1.lastIndex());
+        assertEquals(0, min1.getMinimum(min1.firstIndex()));
+        assertEquals(590, min1.getMaximum(min1.firstIndex()));
+        assertEquals(295d, min1.getAverage(min1.firstIndex()), 0.1d);
+        assertEquals(60, min1.getNumberOfPoints(min1.firstIndex()));
+        assertEquals(OFFSET_FROM_ABSOLUTE_ZERO.toMillis(), min1.getTime(min1.firstIndex()));
+        assertEquals(600, min1.getMinimum(min1.lastIndex()));
+        assertEquals(1190, min1.getMaximum(min1.lastIndex()));
+        assertEquals(895d, min1.getAverage(min1.lastIndex()), 0.1d);
+        assertEquals(60, min1.getNumberOfPoints(min1.lastIndex()));
+        assertEquals(OFFSET_FROM_ABSOLUTE_ZERO.plusMinutes(1).toMillis(), min1.getTime(min1.lastIndex()));
+    }
+
+    @Test
+    public void threeDaysAggregate() {
+        int secondsIn3Days = (int) (Duration.ofDays(3).toMinutes() * 60);
+        SeriesDataset set = createDatasetWithSeconds(secondsIn3Days, 10);
+        assertEquals(3, set.getRecentMinutes().getRecentHours().getRecentDays().size());
+    }
+
+    private static SeriesDataset createDatasetWithSeconds(int secondsToAdd, int delta) {
+        SeriesDataset set = emptySeconds(60);
+        long time = OFFSET_FROM_ABSOLUTE_ZERO.toMillis();
+        long value = 0L;
+        for (int i = 0; i < secondsToAdd; i++) {
+            set = set.add(time, value, true);
+            time += 1000L;
+            value += delta;
+        }
+        return set;
     }
 
     private static EmptyDataset emptySeconds(int capacity) {
         return new EmptyDataset("instance", new Series("series"), capacity);
-    }
-
-    private static SeriesDataset minuteAfter(SeriesDataset minuteBefore, long delta) {
-        SeriesDataset set = minuteBefore;
-        boolean empty = minuteBefore.size() == 0;
-        long time = empty ? 59500L : minuteBefore.lastTime();
-        long value = empty ? 0L : minuteBefore.lastValue();
-        for (int i = 0; i < 60; i++) {
-            time += 1000L;
-            value += delta;
-            set = set.add(time, value);
-        }
-        return set;
     }
 }

--- a/process/src/test/java/fish/payara/monitoring/model/MinutesDatasetTest.java
+++ b/process/src/test/java/fish/payara/monitoring/model/MinutesDatasetTest.java
@@ -1,0 +1,39 @@
+package fish.payara.monitoring.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MinutesDatasetTest {
+
+    @Test
+    public void emptyMinutesAddOne() {
+        MinutesDataset min1 = MinutesDataset.EMPTY.add(minuteAfter(emptySeconds(60), 10));
+        assertEquals(1, min1.size());
+        assertEquals(min1.firstIndex(), min1.lastIndex());
+        assertEquals(1, min1.firstIndex());
+        assertEquals(1, min1.lastIndex());
+        assertEquals(10, min1.getMinimum(min1.firstIndex()));
+        assertEquals(600, min1.getMaximum(min1.firstIndex()));
+        assertEquals(305d, min1.getAverage(min1.firstIndex()), 0.1d);
+        assertEquals(60, min1.getNumberOfPoints(min1.firstIndex()));
+        assertEquals(60000L, min1.getTime(min1.firstIndex()));
+    }
+
+    private static EmptyDataset emptySeconds(int capacity) {
+        return new EmptyDataset("instance", new Series("series"), capacity);
+    }
+
+    private static SeriesDataset minuteAfter(SeriesDataset minuteBefore, long delta) {
+        SeriesDataset set = minuteBefore;
+        boolean empty = minuteBefore.size() == 0;
+        long time = empty ? 59500L : minuteBefore.lastTime();
+        long value = empty ? 0L : minuteBefore.lastValue();
+        for (int i = 0; i < 60; i++) {
+            time += 1000L;
+            value += delta;
+            set = set.add(time, value);
+        }
+        return set;
+    }
+}

--- a/process/src/test/java/fish/payara/monitoring/model/SeriesDatasetTest.java
+++ b/process/src/test/java/fish/payara/monitoring/model/SeriesDatasetTest.java
@@ -45,6 +45,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -55,7 +57,7 @@ import fish.payara.monitoring.model.SeriesDataset;
 /**
  * Tests the basic correctness of {@link SeriesDataset} implementation, in particular the correctness of the sliding
  * window mechanism.
- * 
+ *
  * @author Jan Bernitt
  */
 public class SeriesDatasetTest {
@@ -119,7 +121,7 @@ public class SeriesDatasetTest {
         set = set.add(6, 6);
         assertFalse(set1.isOutdated());
         assertValues(set, 4, 5, 6);
-        // did slide by capacity 
+        // did slide by capacity
         set = set.add(7, 7);
         assertTrue(set.isOutdated());
         assertValues(set, 5, 6, 7);
@@ -315,6 +317,18 @@ public class SeriesDatasetTest {
             assertEquals(msg, i, set.lastTime());
             assertEquals(msg, 5, set.lastValue());
             assertEquals(msg, 2 + ((i - 2) * 2), set.getObservedValues());
+        }
+    }
+
+    @Test
+    public void endOfMinuteIdentifiedCorrectly() {
+        SeriesDataset set = new EmptyDataset(INSTANCE, SERIES, 120);
+        long nowNoMillis = System.currentTimeMillis() / 1000 * 1000;
+        for (int i = 0; i < 120; i++) {
+            set = set.add(nowNoMillis, i + 1);
+            assertEquals(Instant.ofEpochMilli(nowNoMillis).atOffset(ZoneOffset.UTC).getSecond() == 59,
+                    set.isEndOfMinute());
+            nowNoMillis += 1000L;
         }
     }
 

--- a/process/src/test/java/fish/payara/monitoring/model/SeriesDatasetTest.java
+++ b/process/src/test/java/fish/payara/monitoring/model/SeriesDatasetTest.java
@@ -327,7 +327,7 @@ public class SeriesDatasetTest {
         for (int i = 0; i < 120; i++) {
             set = set.add(nowNoMillis, i + 1);
             assertEquals(Instant.ofEpochMilli(nowNoMillis).atOffset(ZoneOffset.UTC).getSecond() == 59,
-                    set.isEndOfMinute());
+                    set.endsWithLastSecondOfMinute());
             nowNoMillis += 1000L;
         }
     }

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -112,6 +112,7 @@ options    = {
 	drawMinLine:boolean,
 	drawMaxLine:boolean,
 	drawAvgLine:boolean,
+	drawAggregates:boolean,
 	perSec:boolean,
 	decimalMetric:boolean,
 	drawCurves:boolean,

--- a/webapp/JS_DOCS.md
+++ b/webapp/JS_DOCS.md
@@ -112,7 +112,7 @@ options    = {
 	drawMinLine:boolean,
 	drawMaxLine:boolean,
 	drawAvgLine:boolean,
-	drawAggregates:boolean,
+	drawAggregates,
 	perSec:boolean,
 	decimalMetric:boolean,
 	drawCurves:boolean,
@@ -122,6 +122,7 @@ options    = {
 	noAnnotations:boolean,
 	noConstantZero:boolean,
 }
+drawAggregates = boolean | 'hour' | 'day' | 'month'
 decorations= { waterline, thresholds, alerts, annotations }
 waterline  = { value:number color:string }
 thresholds = { reference, alarming, critical }

--- a/webapp/src/main/java/fish/payara/monitoring/web/ApiRequests.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/ApiRequests.java
@@ -105,6 +105,8 @@ public final class ApiRequests {
 
         public DataType[] exclude;
 
+        public boolean history;
+
         public SeriesQuery() {
             // from JSON
         }

--- a/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
+++ b/webapp/src/main/java/fish/payara/monitoring/web/ApiResponses.java
@@ -139,7 +139,7 @@ public final class ApiResponses {
             this.series = series;
             this.alerts = alerts.stream().map(alert -> new AlertData(alert, query.truncates(ALERTS))).collect(toList());
             this.watches = watches.stream().map(WatchData::new).collect(toList());
-            this.data = data.stream().map(set -> new SeriesData(set, query.truncates(POINTS))).collect(toList());
+            this.data = data.stream().map(set -> new SeriesData(set, query.truncates(POINTS), query.history)).collect(toList());
             this.annotations = annotations.stream().map(AnnotationData::new).collect(toList());
         }
 
@@ -286,10 +286,10 @@ public final class ApiResponses {
         public final AggregatedSeriesData days;
 
         public SeriesData(SeriesDataset set) {
-            this(set, false);
+            this(set, false, false);
         }
 
-        public SeriesData(SeriesDataset set, boolean truncatePoints) {
+        public SeriesData(SeriesDataset set, boolean truncatePoints, boolean history) {
             this.instance = set.getInstance();
             this.series = set.getSeries().toString();
             this.points = truncatePoints ? new long[] {set.lastTime(), set.lastValue()} : set.points();
@@ -301,7 +301,7 @@ public final class ApiResponses {
             this.observedSince = set.getObservedSince();
             this.stableCount = set.getStableCount();
             this.stableSince = set.getStableSince();
-            if (truncatePoints) {
+            if (!history || truncatePoints) {
                 this.minutes = null;
                 this.hours = null;
                 this.days = null;
@@ -418,12 +418,12 @@ public final class ApiResponses {
 
         public AlertFrame(Alert.Frame frame) {
             this.level = frame.level.name().toLowerCase();
-            this.cause = new SeriesData(frame.cause, true); // for now the points data isn't used, change to false if needed
+            this.cause = new SeriesData(frame.cause, true, false); // for now the points data isn't used, change to false if needed
             this.start = frame.start;
             this.end = frame.getEnd() <= 0 ? null : frame.getEnd();
             this.captured = new ArrayList<>();
             for (SeriesDataset capture : frame) {
-                this.captured.add(new SeriesData(capture, true)); // for now the points data isn't used, change to false if needed
+                this.captured.add(new SeriesData(capture, true, false)); // for now the points data isn't used, change to false if needed
             }
         }
     }

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -49,8 +49,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=t"></script>
-    <link href="css/monitoring-console.css?x=t" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=r"></script>
+    <link href="css/monitoring-console.css?x=r" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -49,8 +49,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
 
-    <script src="js/monitoring-console.js?x=g"></script>
-    <link href="css/monitoring-console.css?x=g" rel="stylesheet" type="text/css">
+    <script src="js/monitoring-console.js?x=t"></script>
+    <link href="css/monitoring-console.css?x=t" rel="stylesheet" type="text/css">
 </head>
 <body id="console">
 

--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -506,7 +506,8 @@ MonitoringConsole.Model = (function() {
 	      			widgetId: 'auto', 
 	      			series: page.content.series,
 	      			truncate: ['ALERTS'],
-	      			exclude: []
+	      			exclude: [],
+	      			history: false,
       			}]}, 
       			(response) => resolve(response.matches),
       			() => reject(undefined));
@@ -1368,11 +1369,12 @@ MonitoringConsole.Model = (function() {
 
 		function pushQueryItems(widget, queries, truncate, exclude) {
 			const series = widget.series;
+			const history = widget.options.drawAggregates === true;
 			const id = widget.id;
 			if (Array.isArray(series)) {
-				series.forEach(s => queries.push({ widgetId: id, series: s, truncate: truncate, exclude: exclude, instances: undefined}));
+				series.forEach(s => queries.push({ widgetId: id, series: s, truncate: truncate, exclude: exclude, instances: undefined, history: history }));
 			} else {
-				queries.push({ widgetId: id, series: series, truncate: truncate, exclude: exclude, instances: undefined}); 
+				queries.push({ widgetId: id, series: series, truncate: truncate, exclude: exclude, instances: undefined, history: history }); 
 			}
 		}
 

--- a/webapp/src/main/webapp/js/mc-model.js
+++ b/webapp/src/main/webapp/js/mc-model.js
@@ -1142,12 +1142,40 @@ MonitoringConsole.Model = (function() {
 	 */ 
 	let Update = (function() {
 
+		function addHistory(widget, data) {
+			function prependPoints(dest, src, time0, interval) {
+				let mostPastTime = dest[0];
+				let time = time0;
+				const prepended = [];
+				for (let i = 0; i < src.length; i++) {
+					if (time < mostPastTime) {
+						prepended.push(time);
+						prepended.push(src[i]);
+					}
+					time += interval;
+				}
+				return prepended.length == 0 ? dest : prepended.concat(dest);
+			}
+			const aggregates = widget.options.drawAggregates;
+			data.forEach(function(seriesData) {
+				if (seriesData.minutes && aggregates !== false)
+					seriesData.points = prependPoints(seriesData.points, seriesData.minutes.avgs, seriesData.minutes.start, seriesData.minutes.interval);
+				if (seriesData.hours && (aggregates === true || aggregates == 'day' || aggregates == 'month'))
+					seriesData.points = prependPoints(seriesData.points, seriesData.hours.avgs, seriesData.hours.start, seriesData.hours.interval);
+				if (seriesData.days && (aggregates === true || aggregates == 'month'))
+					seriesData.points = prependPoints(seriesData.points, seriesData.days.avgs, seriesData.days.start, seriesData.days.interval);
+			});
+			return data;		
+		}
+
 		/**
 		 * Shortens the shown time frame to one common to all series but at least to the last minute.
 		 */
-		function retainCommonTimeFrame(data) {
+		function retainCommonTimeFrame(widget, data) {
 			if (!data || data.length == 0)
 				return [];
+			if (widget.options.drawAggregates !== false && widget.options.drawAggregates !== undefined)
+				return addHistory(widget, data);
 			let now = Date.now();
 			let startOfLastMinute = now - 60000;
 			let startOfShortestSeries = data.reduce((high, e) => Math.max(e.points[0], high), 0);
@@ -1297,7 +1325,7 @@ MonitoringConsole.Model = (function() {
 					}
 					for (let alert of alerts)
 						alert.confirmed = confirmedAlertsSerials.includes(alert.serial);
-					data = retainCommonTimeFrame(data);
+					data = retainCommonTimeFrame(widget, data);
 					if (widget.options.decimalMetric || widget.scaleFactor !== undefined && widget.scaleFactor !== 1)
 						adjustDecimals(data, widget.scaleFactor ? widget.scaleFactor : 1,  widget.options.decimalMetric ? 10000 : 1);
 					if (widget.options.perSec)
@@ -1369,7 +1397,7 @@ MonitoringConsole.Model = (function() {
 
 		function pushQueryItems(widget, queries, truncate, exclude) {
 			const series = widget.series;
-			const history = widget.options.drawAggregates === true;
+			const history = widget.options.drawAggregates !== false && widget.options.drawAggregates !== undefined;
 			const id = widget.id;
 			if (Array.isArray(series)) {
 				series.forEach(s => queries.push({ widgetId: id, series: s, truncate: truncate, exclude: exclude, instances: undefined, history: history }));

--- a/webapp/src/main/webapp/js/mc-view-components.js
+++ b/webapp/src/main/webapp/js/mc-view-components.js
@@ -170,8 +170,11 @@ MonitoringConsole.View.Components = (function() {
         }
         let onChange = enhancedOnChange(model.onChange, true);
         dropdown.change(() => {
-          const val = dropdown.val(); 
-          onChange(val == '_' ? undefined : val);
+          let val = dropdown.val();
+          if (val === '_') val = undefined;
+          if (val === 'false') val = false;
+          if (val === 'true') val = true;
+          onChange(val);
         });
         return dropdown;
       }

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -358,6 +358,7 @@ MonitoringConsole.View = (function() {
         ]});
         const lineExtrasAvailable = widget.type == 'line';
         settings.push({ id: 'settings-decorations', caption: 'Extras', collapsed: true, entries: [
+            { label: 'History', type: 'toggle', options: { true: 'Yes', false: 'No'}, value: widget.options.drawAggregates || false, onChange: (widget, checked) => widget.options.drawAggregates = checked },
             { label: 'Annotations', input: [
                 { label: 'show', type: 'checkbox', value: !options.noAnnotations, onChange: (widget, checked) => widget.options.noAnnotations = !checked},
             ]},
@@ -367,7 +368,7 @@ MonitoringConsole.View = (function() {
                 { label: 'Min', type: 'checkbox', value: options.drawMinLine, onChange: (widget, checked) => widget.options.drawMinLine = checked},
                 { label: 'Max', type: 'checkbox', value: options.drawMaxLine, onChange: (widget, checked) => widget.options.drawMaxLine = checked},
                 { label: 'Avg', type: 'checkbox', value: options.drawAvgLine, onChange: (widget, checked) => widget.options.drawAvgLine = checked},            
-            ]},            
+            ]},
             { label: 'Waterline', available: lineExtrasAvailable, input: [
                 { type: 'value', unit: unit, value: widget.decorations.waterline.value, onChange: (widget, value) => widget.decorations.waterline.value = value },
                 { type: 'color', value: widget.decorations.waterline.color, defaultValue: Theme.color('waterline'), onChange: (widget, value) => widget.decorations.waterline.color = value },
@@ -1105,7 +1106,8 @@ MonitoringConsole.View = (function() {
                     widgetId: 'auto', 
                     series: '?:* *',
                     truncate: ['ALERTS', 'POINTS'],
-                    exclude: []
+                    exclude: [],
+                    history: false,
                 }]}, 
                 (response) => resolve(response.matches),
                 () => reject(undefined));

--- a/webapp/src/main/webapp/js/mc-view.js
+++ b/webapp/src/main/webapp/js/mc-view.js
@@ -358,7 +358,8 @@ MonitoringConsole.View = (function() {
         ]});
         const lineExtrasAvailable = widget.type == 'line';
         settings.push({ id: 'settings-decorations', caption: 'Extras', collapsed: true, entries: [
-            { label: 'History', type: 'toggle', options: { true: 'Yes', false: 'No'}, value: widget.options.drawAggregates || false, onChange: (widget, checked) => widget.options.drawAggregates = checked },
+            { label: 'History', type: 'dropdown', options: { _: 'None', hour: '1 Hour', day: '1 Day', month: '1 Month'}, value: widget.options.drawAggregates || '_', onChange: (widget, checked) => widget.options.drawAggregates = checked,
+                description: 'What period of aggregated history to show in the graph' },
             { label: 'Annotations', input: [
                 { label: 'show', type: 'checkbox', value: !options.noAnnotations, onChange: (widget, checked) => widget.options.noAnnotations = !checked},
             ]},


### PR DESCRIPTION
### Summary
This PR adds a new capability to InSight where the points collected (usually each second) are aggregated once per minute into a min/max/avg value for the aggregated time-frame. The minute aggregates themselves are aggregated into min/max/avg values for each hour which again are aggregated into aggregates for one day.

This means to the existing sliding window of the recent minute with (usually) seconds precision further sliding windows are added:
* recent hour with 1 point per minute
* recent day with 1 point per hour
* recent month with 1 point per day

This aggregation data is only collected when enabled using a new command option (default is disabled):

```
asadmin set-monitoring-console-configuration --history-enabled=true
```
When enabled aggregation takes place and over time an aggregated history up to the most recent month is building up.
When disabled the so far aggregated data is discarded to free memory. 

Overall memory needed for the aggregated history is moderate. Aggregation only occurs on the DAS instance. Aggregated data is only send to the client if explicitly requested by a added `history` flag in the query.
The flag is controlled by a new widget _Extras_ option which by default will not show any history (most recent minute data only). Users can opt to show most recent hour, most recent day or most recent month.

### Limitations
While the aggregation collect minimum, maximum and average value for the aggregated time-frame as well as the number of points this aggregate is based upon so far only the average value is used and shown as if the averages were the current value at the aggregate point in time when history is enabled. In the future the data should be used to visualise a range between min and max in addition to the line being drawn along the average values.

### Testing
#### Performed Testing
* build InSight (as snapshot version)
* modify Payara Enterprise PR https://github.com/payara/Payara-Enterprise/pull/246 root `pom.xml` to use the built snapshot versions (PR is naturally made to use the not yet released version created after this PR is merged)
* build Payara Enterprise and start it (`asadmin start-domain production`)
* open InSight
* enable aggregated history by running following asadmin command: `asadmin set-monitoring-console-configuration --history-enabled=true`
* have it run for some minutes/hours (at least 5+ minutes)
* select a widget, for example _Heap Memory_ on _Core_ page
* select the _Extras_ tab of the widget settings
* change _History_ from _None_ to some other settings and verify the data shown in the graph goes from 60 seconds to minutes or hours
* add a new widget showing the _Total Bytes Memory_ metric (search for it) and configure it to show unit _Bytes_
* disable aggregated history by asadmin command `asadmin set-monitoring-console-configuration --history-enabled=false`
* verify that the memory used as shown by _Total Bytes Memory_ makes a step down after the configuration change (this can take a while as it needs GC to happen)

### Documentation
https://github.com/payara/Payara-Enterprise-Documentation/pull/83

### Examples
![FISH-752-2](https://user-images.githubusercontent.com/309438/99665711-4bb53980-2a6a-11eb-9440-675234db51fd.png)
![FISH-752](https://user-images.githubusercontent.com/309438/99665716-4ce66680-2a6a-11eb-8625-1fd01c67372e.png)

After being changed to 1 hour history (and with history enabled via asadmin!) the graph shows the past 16 mins (as this is how much data had been collected at that point). Notice that the most recent data on the right in the graph shows finer stepping - this is because the recent minute has second level resolution while the minutes further in the past have only minute level resolution. 

![FISH-752-3](https://user-images.githubusercontent.com/309438/99667387-9cc62d00-2a6c-11eb-87f3-603d751f4aef.png)
Same graph after 33mins