### PR TITLE
FISH-8635 FISH-8664 Payara 7 Version of Monitoring Console

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
               <groupId>org.apache.felix</groupId>
               <artifactId>maven-bundle-plugin</artifactId>
-              <version>4.2.1</version>
+              <version>${version.maven.bundle.plugin}</version>
               <executions>
                 <execution>
                   <id>bundle-manifest</id>
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
-            <version>3.0.1.payara-p1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2020-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.2</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <version.jakarta.json-api>2.1.3</version.jakarta.json-api>
         <version.jakarta.ws.rs-api>4.0.0</version.jakarta.ws.rs-api>
 
-        <version.hk2>4.0.0-M2.payara-p1</version.hk2>
+        <version.hk2>4.0.0-M2.payara-p2</version.hk2>
         <version.parsson>1.1.6</version.parsson>
 
         <version.java>21</version.java>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,16 @@
             </snapshots>
         </repository>
 
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2020-2024 Payara Foundation and/or its affiliates. All rights reserved.
  
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -77,7 +77,7 @@
         <version.jakarta.ws.rs-api>4.0.0</version.jakarta.ws.rs-api>
 
         <version.hk2>4.0.0-M2.payara-p1</version.hk2>
-        <version.jakarta.json-impl>2.0.1</version.jakarta.json-impl>
+        <version.parsson>1.1.6</version.parsson>
 
         <version.java>21</version.java>
         <version.maven.enforcer.java.limit>22</version.maven.enforcer.java.limit>
@@ -158,9 +158,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.glassfish</groupId>
+                <groupId>org.eclipse.parsson</groupId>
                 <artifactId>jakarta.json</artifactId>
-                <version>${version.jakarta.json-impl}</version>
+                <version>${version.parsson}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.2</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -57,16 +57,30 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         
-        <version.maven.source.plugin>3.2.0</version.maven.source.plugin>
-        <version.maven.jar.plugin>3.2.0</version.maven.jar.plugin>
-        <version.maven.gpg.plugin>1.6</version.maven.gpg.plugin>
-        <version.maven.javadoc.plugin>3.1.1</version.maven.javadoc.plugin>        
-        
-        <version.java>1.8</version.java>
-        <version.maven.enforcer.java.limit>1.9</version.maven.enforcer.java.limit>
+        <version.maven.source.plugin>3.3.1</version.maven.source.plugin>
+        <version.maven.jar.plugin>3.4.1</version.maven.jar.plugin>
+        <version.maven.gpg.plugin>3.2.4</version.maven.gpg.plugin>
+        <version.maven.javadoc.plugin>3.6.3</version.maven.javadoc.plugin>
+        <version.maven.enforcer.plugin>3.4.1</version.maven.enforcer.plugin>
+        <version.maven.nexus.staging.plugin>1.6.13</version.maven.nexus.staging.plugin>
+        <version.maven.release.plugin>3.0.1</version.maven.release.plugin>
+        <version.maven.bundle.plugin>5.1.9</version.maven.bundle.plugin>
+        <version.maven.merge.plugin>1.2.0</version.maven.merge.plugin>
+
+        <version.jakarta.jakartaee-api>11.0.0-M2</version.jakarta.jakartaee-api>
+        <version.jakarta.servlet-api>6.1.0-M2</version.jakarta.servlet-api>
+        <version.jakarta.json.bind-api>3.0.1</version.jakarta.json.bind-api>
+        <version.jakarta.json-api>2.1.3</version.jakarta.json-api>
+        <version.jakarta.ws.rs-api>4.0.0</version.jakarta.ws.rs-api>
+
+        <version.hk2>4.0.0-M2.payara-p1</version.hk2>
+        <version.jakarta.json-impl>2.0.1</version.jakarta.json-impl>
+
+        <version.java>21</version.java>
+        <version.maven.enforcer.java.limit>22</version.maven.enforcer.java.limit>
     </properties>
 
     <scm>
@@ -127,54 +141,6 @@
             </snapshots>
         </repository>
 
-        <repository>
-            <id>jvnet-nexus-releases</id>
-            <name>Java.net Releases Repositories</name>
-            <url>https://maven.java.net/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-staging</id>
-            <name>Java.net Staging Repositories</name>
-            <url>https://maven.java.net/content/repositories/staging</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-promoted</id>
-            <name>Java.net Promoted Repositories</name>
-            <url>https://maven.java.net/content/repositories/promoted/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>payara-patched-externals</id>
-            <name>Payara Patched Externals</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
     </repositories>
 
     <modules>
@@ -183,14 +149,100 @@
         <module>webapp</module>
     </modules>
 
-    <build>
-        <plugins>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-api</artifactId>
+                <version>${version.hk2}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.json</artifactId>
+                <version>${version.jakarta.json-impl}</version>
+                <scope>provided</scope>
+            </dependency>
 
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${version.jakarta.servlet-api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${version.jakarta.json.bind-api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${version.jakarta.json-api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws.rs-api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
+                <version>${version.jakarta.jakartaee-api}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${version.maven.jar.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${version.maven.source.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${version.maven.javadoc.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${version.maven.nexus.staging.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${version.maven.release.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${version.maven.enforcer.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.bekioui.maven.plugin</groupId>
+                    <artifactId>merge-maven-plugin</artifactId>
+                    <version>${version.maven.merge.plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
             <!-- Configure the jar with the binaries. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.maven.jar.plugin}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -209,7 +261,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${version.maven.source.plugin}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -224,14 +275,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${version.maven.javadoc.plugin}</version>
                 <configuration>
                     <javadocVersion>${version.java}</javadocVersion>
                     <notimestamp>true</notimestamp>
                     <splitindex>true</splitindex>
                     <doctitle>Monitoring Console</doctitle>
                     <links>
-                        <link>https://docs.oracle.com/javaee/${version.javaee}/api/</link>
+                        <link>https://jakarta.ee/specifications/platform/11/apidocs/</link>
                     </links>
                 </configuration>
                 <executions>
@@ -247,7 +297,6 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -257,6 +306,7 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -269,7 +319,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -280,14 +329,13 @@
                             <rules>
                                 <requireJavaVersion>
                                     <version>[${version.java},${version.maven.enforcer.java.limit})</version>
-                                    <message>JDK8 only please</message>
+                                    <message>JDK21 only please</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 
@@ -295,12 +343,20 @@
         <profile>
             <id>release</id>
             <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-gpg-plugin</artifactId>
+                            <version>${version.maven.gpg.plugin}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <!-- Signing with GPG is a requirement for a release deployment to Maven central. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>${version.maven.gpg.plugin}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -313,6 +369,22 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>jakarta-staging</id>
+            <repositories>
+                <repository>
+                    <id>jakarta-releases</id>
+                    <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
 </project>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -56,13 +56,6 @@
         This module contains the main library of the monitoring console that runs the monitoring proccessing
     </description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
-
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -77,7 +70,7 @@
             <plugin>
               <groupId>org.apache.felix</groupId>
               <artifactId>maven-bundle-plugin</artifactId>
-              <version>4.2.1</version>
+              <version>${version.maven.bundle.plugin}</version>
               <executions>
                 <execution>
                   <id>bundle-manifest</id>
@@ -102,19 +95,16 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.2</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2020-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -81,6 +81,13 @@
                 </execution>
               </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -103,7 +110,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -59,10 +59,6 @@
     </description>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
 
@@ -101,7 +97,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.0.0</version>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -112,7 +108,6 @@
             <plugin>
               <groupId>com.bekioui.maven.plugin</groupId>
               <artifactId>merge-maven-plugin</artifactId>
-              <version>1.2.0</version>
               <executions>
                 <execution>
                   <id>merge-files</id>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2019-2020] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2019-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.2</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>


### PR DESCRIPTION
**NOTE - JAVADOC NEEDS ATTENTION** - Skip with `-Ddoclint=none`

Upgrades Java version to 21.
Upgrades many build plugins.
Upgrades EE APIs to EE 11 versions.
Upgrades HK2 to 4.0.0
Swaps GlassFish JSON to Parsson 1.1.6.

**Requires**  https://github.com/payara/patched-src-hk2/pull/34