### PR TITLE
FISH-8669 POM versioning changes and cleanup

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.11-SNAPSHOT</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.10</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2020-2025] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.9</version>
+        <version>1.10</version>
     </parent>
 
     <artifactId>monitoring-console-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2020-2025] Payara Foundation and/or its affiliates. All rights reserved.
  
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.9</version>
+    <version>1.10</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,11 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>payara-nexus-enterprise-snapshots</id>
             <url>https://nexus.dev.payara.fish/repository/payara-enterprise-snapshots-private</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
+            <id>payara-nexus-enterprise-artifacts</id>
             <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private</url>
         </repository>
     </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>1.10</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.10</version>
+    <version>1.11-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.10</version>
+    <version>1.10-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>
@@ -97,11 +97,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-snapshots-private</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private</url>
         </repository>
     </distributionManagement>
 
@@ -231,18 +231,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <groupId>fish.payara.monitoring-console</groupId>
     <artifactId>parent</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.10</version>
     <packaging>pom</packaging>
 
     <name>Payara Monitoring Console Parent</name>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.10</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.11-SNAPSHOT</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2020-2025] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -46,7 +46,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.9</version>
+        <version>1.10</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>

--- a/process/pom.xml
+++ b/process/pom.xml
@@ -46,10 +46,11 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-process</artifactId>
+    <version>1.10-SNAPSHOT</version>
     <name>monitoring-console-process</name>
 
     <description>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.10</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.11-SNAPSHOT</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -49,6 +49,7 @@
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>
+    <version>1.10-SNAPSHOT</version>
 
     <packaging>war</packaging>
 
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>fish.payara.monitoring-console</groupId>
             <artifactId>monitoring-console-process</artifactId>
-            <version>${project.version}</version>
+            <version>1.10-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.10-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2019-2021] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) [2019-2025] Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.9</version>
+        <version>1.10</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,11 +45,11 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.11-SNAPSHOT</version>
+        <version>1.10</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>
-    <version>1.10-SNAPSHOT</version>
+    <version>1.10</version>
 
     <packaging>war</packaging>
 
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>fish.payara.monitoring-console</groupId>
             <artifactId>monitoring-console-process</artifactId>
-            <version>1.10-SNAPSHOT</version>
+            <version>1.9</version>
             <scope>provided</scope>
         </dependency>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10-SNAPSHOT</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,11 +45,11 @@
     <parent>
         <groupId>fish.payara.monitoring-console</groupId>
         <artifactId>parent</artifactId>
-        <version>1.10</version>
+        <version>1.11-SNAPSHOT</version>
     </parent>
         
     <artifactId>monitoring-console-webapp</artifactId>
-    <version>1.10</version>
+    <version>1.11-SNAPSHOT</version>
 
     <packaging>war</packaging>
 
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>fish.payara.monitoring-console</groupId>
             <artifactId>monitoring-console-process</artifactId>
-            <version>1.9</version>
+            <version>1.10-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Changed POM versioning for each section to represent its current version and changed the version to 1.10-SNAPSHOT.
Removed nexus plugin from parent POM.
Changed distributionManagement to reflect the correct URLs as a result of a previous suggestion by Andrew.