### PR TITLE
FISH-8942 Bump maven-war-plugin to 3.5.1 and final jakarta api releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
     tools {
         jdk "zulu-21"
-        maven "maven-3.6.3"
+        maven "maven-3.9.9"
     }
     environment {
         JAVA_HOME = tool("zulu-21")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 script {
                     echo '*#*#*#*#*#*#*#*#*#*#*#*#  Building SRC  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                     sh """mvn -B -V -ff -e clean install --strict-checksums \
-                        -Djavadoc.skip -Dsource.skip"""
+                        -Dmaven.javadoc.skip -Dsource.skip"""
                     echo '*#*#*#*#*#*#*#*#*#*#*#*#    Built SRC   *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
         <version.maven.bundle.plugin>5.1.9</version.maven.bundle.plugin>
         <version.maven.merge.plugin>1.2.0</version.maven.merge.plugin>
 
-        <version.jakarta.jakartaee-api>11.0.0-M2</version.jakarta.jakartaee-api>
-        <version.jakarta.servlet-api>6.1.0-M2</version.jakarta.servlet-api>
+        <version.jakarta.jakartaee-api>11.0.0</version.jakarta.jakartaee-api>
+        <version.jakarta.servlet-api>6.1.0</version.jakarta.servlet-api>
         <version.jakarta.json.bind-api>3.0.1</version.jakarta.json.bind-api>
         <version.jakarta.json-api>2.1.3</version.jakarta.json-api>
         <version.jakarta.ws.rs-api>4.0.0</version.jakarta.ws.rs-api>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -106,6 +106,11 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.5.1</version>
+            </plugin>
+            <plugin>
               <groupId>com.bekioui.maven.plugin</groupId>
               <artifactId>merge-maven-plugin</artifactId>
               <executions>


### PR DESCRIPTION
- Fixes issue with web app component build
- Update jakarta ee api to final version
- Update jakarta servlet api to final version
- Fixed issue with maven  javadoc
- Make PR builds use maven 3.9.9